### PR TITLE
Allow configuration of additional annotations and labels

### DIFF
--- a/charts/lakom/templates/deployment.yaml
+++ b/charts/lakom/templates/deployment.yaml
@@ -13,6 +13,9 @@ metadata:
     helm.sh/chart: {{ .Values.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     high-availability-config.resources.gardener.cloud/type: server
+    {{- if .Values.additionalLabels.deployment }}
+    {{- toYaml .Values.additionalLabels.deployment | trim | nindent 4 }}
+    {{- end }}
 spec:
   revisionHistoryLimit: 5
   replicas: {{ .Values.replicaCount }}
@@ -34,6 +37,9 @@ spec:
       labels:
         app.kubernetes.io/name: {{ .Values.name }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.additionalLabels.deployment }}
+        {{- toYaml .Values.additionalLabels.deployment | trim | nindent 8 }}
+        {{- end }}
     spec:
       {{- if gt (int .Values.replicaCount) 1 }}
       affinity:

--- a/charts/lakom/templates/service.yaml
+++ b/charts/lakom/templates/service.yaml
@@ -11,6 +11,10 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ .Values.name }}
     app.kubernetes.io/instance: {{ .Release.Name }}
+  {{- if .Values.additionalAnnotations.service }}
+  annotations:
+    {{- toYaml .Values.additionalAnnotations.service | trim | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   selector:

--- a/charts/lakom/values.yaml
+++ b/charts/lakom/values.yaml
@@ -58,3 +58,7 @@ vpa:
       memory: 64Mi
   updatePolicy:
     updateMode: "Auto"
+additionalAnnotations:
+  service: {}
+additionalLabels:
+  deployment: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
Allow configuration of additional annotations and labels

Similar to https://github.com/gardener/oidc-webhook-authenticator/pull/113

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to configure additional annotations for the `Service` in the Helm chart via `additionalAnnotations.service`, and additional labels for the `Deployment` via `additionalAnnotations.deployment`.
```
