### PR TITLE
Clean a healthcheck todo and register healthcheck for the shoot managedresource

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -45,8 +45,7 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesSeed),
 			},
 		},
-		// TODO(shafeeqes): Remove this condition in a future version.
-		sets.New(gardencorev1beta1.ShootSystemComponentsHealthy),
+		sets.New[gardencorev1beta1.ConditionType](),
 	)
 }
 

--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -44,6 +44,10 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
 				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesSeed),
 			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
+				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesShoot),
+			},
 		},
 		sets.New[gardencorev1beta1.ConditionType](),
 	)


### PR DESCRIPTION
**What this PR does / why we need it**:
Clean a healthcheck todo and register healthcheck for the shoot managedresource 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
This extension is now also doing health check on the managed resource installing the resources in the shoot cluster.  
```
