### PR TITLE
Remove again healthcheck on shoot class managed resource

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -40,16 +40,13 @@ func RegisterHealthChecks(mgr manager.Manager, opts healthcheck.DefaultAddArgs) 
 		opts,
 		nil,
 		[]healthcheck.ConditionTypeToHealthCheck{
+			// Never register health checks for `managedresource.spec.class==nil` (ManagedResources installing resources in the shoot cluster) here as it is done by gardenlet, see https://github.com/gardener/gardener/blob/v1.71.3/docs/extensions/healthcheck-library.md?plain=1#L99
 			{
 				ConditionType: string(gardencorev1beta1.ShootControlPlaneHealthy),
 				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesSeed),
 			},
-			{
-				ConditionType: string(gardencorev1beta1.ShootSystemComponentsHealthy),
-				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesShoot),
-			},
 		},
-		sets.New[gardencorev1beta1.ConditionType](),
+		sets.New(gardencorev1beta1.ShootSystemComponentsHealthy), // TODO(vpnachev), remove this condition removal in a future version.
 	)
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove again healthcheck on shoot class managed resource


**Which issue(s) this PR fixes**:
Reverts #16 and adds clarification to never register again shoot class managed resources for health checking.  
Fixes https://github.com/gardener/gardener-extension-shoot-lakom-service/pull/16/files#r1217585168

**Special notes for your reviewer**:

cc @shafeeqes 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
This extension again removes the health checks for the shooт managed resource. 
```
