### PR TITLE
Mitigate wrongly returned NoMatchingSignature error when context is canceled

### DIFF
--- a/pkg/lakom/verifysignature/verifier.go
+++ b/pkg/lakom/verifysignature/verifier.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto"
 	"fmt"
+	"strings"
 
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/constants"
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/metrics"
@@ -86,6 +87,12 @@ func verify(ctx context.Context, imageRef name.Reference, keys []crypto.PublicKe
 			}
 
 			if IsNoMatchingSignature(err) {
+				if strings.Contains(err.Error(), "context canceled") {
+					// Mitigation for https://github.com/gardener/gardener-extension-shoot-lakom-service/issues/25
+					// TODO(vpnachev): remove when https://github.com/sigstore/cosign/issues/3133 is fixed and vendored
+					return false, err
+				}
+
 				log.Info("no matching signatures found for current public key", "error", err.Error())
 				continue
 			}

--- a/pkg/lakom/verifysignature/verifier.go
+++ b/pkg/lakom/verifysignature/verifier.go
@@ -7,8 +7,8 @@ package verifysignature
 import (
 	"context"
 	"crypto"
+	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/constants"
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/metrics"
@@ -87,7 +87,7 @@ func verify(ctx context.Context, imageRef name.Reference, keys []crypto.PublicKe
 			}
 
 			if IsNoMatchingSignature(err) {
-				if strings.Contains(err.Error(), "context canceled") {
+				if errors.Is(err, context.Canceled) {
 					// Mitigation for https://github.com/gardener/gardener-extension-shoot-lakom-service/issues/25
 					// TODO(vpnachev): remove when https://github.com/sigstore/cosign/issues/3133 is fixed and vendored
 					return false, err

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -85,10 +85,8 @@ IqozONbbdbqz11hlRJy9c7SG+hdcFl9jE9uE/dwtuwU2MqU9T/cN0YkWww==
 
 		It("Should fail image verification when context is canceled", func() {
 			canceledCtx, cancel := context.WithCancel(ctx)
-			go func() {
-				time.Sleep(time.Millisecond * 10)
-				cancel()
-			}()
+			cancel()
+
 			verified, err := directVerifier.Verify(canceledCtx, "eu.gcr.io/gardener-project/gardener/apiserver@sha256:249ea7f1d0439a94893b486e7820f6f0ab52522c5f22e1bad21782d6381e739e", kcr)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("context canceled"))
@@ -156,10 +154,7 @@ IqozONbbdbqz11hlRJy9c7SG+hdcFl9jE9uE/dwtuwU2MqU9T/cN0YkWww==
 
 		It("Should not cache failed image verification when context is canceled", func() {
 			canceledCtx, cancel := context.WithCancel(ctx)
-			go func() {
-				time.Sleep(time.Millisecond * 10)
-				cancel()
-			}()
+			cancel()
 
 			image := "eu.gcr.io/gardener-project/gardener/apiserver@sha256:249ea7f1d0439a94893b486e7820f6f0ab52522c5f22e1bad21782d6381e739e"
 			verified, err := cachedVerifier.Verify(canceledCtx, image, kcr)


### PR DESCRIPTION
**What this PR does / why we need it**:
Mitigate wrongly returned `NoMatchingSignature` error when context is canceled

**Which issue(s) this PR fixes**:
Mitigates #25 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug that was caching image signature verification status as unsigned due to wrongly returned `NoMatchingSignature` by the SDK is now mitigated. 
```
