### PR TITLE
Remove temporary code cleaning secrets from the namespace of the extension

### DIFF
--- a/pkg/controller/seed/reconciler.go
+++ b/pkg/controller/seed/reconciler.go
@@ -139,17 +139,7 @@ func (kcr *kubeSystemReconciler) reconcile(ctx context.Context, logger logr.Logg
 		return err
 	}
 
-	if err := kcr.setOwnerReferenceToSecrets(ctx, ownerNamespace); err != nil {
-		return err
-	}
-
-	// TODO(vpnachev): Remove the clean up secret manager in a future version of the extension.
-	legacySecretManager, err := secretsmanager.New(ctx, logger.WithName("legacy-seed-secretsmanager"), clock.RealClock{}, kcr.client, ownerNamespace, "gardener-extension-shoot-lakom-service-seed-webhook", secretsmanager.Config{})
-	if err != nil {
-		return fmt.Errorf("failed to create legacy secret manager in namespace: %q, err: %w", ownerNamespace, err)
-	}
-
-	return legacySecretManager.Cleanup(ctx)
+	return kcr.setOwnerReferenceToSecrets(ctx, ownerNamespace)
 }
 
 func getLabels() map[string]string {


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove temporary code cleaning secrets from the namespace of the extension

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
