### PR TITLE
Drop support for Shoots with k8s < 1.24

### DIFF
--- a/pkg/lakom/resolvetag/admission.go
+++ b/pkg/lakom/resolvetag/admission.go
@@ -126,12 +126,6 @@ func (h *handler) Handle(ctx context.Context, request admission.Request) admissi
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	// TODO: Remove namespace population once support for k8s <1.24 is dropped
-	// Ref: https://github.com/kubernetes/kubernetes/pull/94637
-	if pod.GetNamespace() == "" {
-		pod.SetNamespace(request.Namespace)
-	}
-
 	logger := h.logger.WithValues("pod", client.ObjectKeyFromObject(pod))
 
 	if err := h.handlePod(ctx, pod, logger); err != nil {

--- a/pkg/lakom/verifysignature/admission.go
+++ b/pkg/lakom/verifysignature/admission.go
@@ -146,12 +146,6 @@ func (h *handler) Handle(ctx context.Context, request admission.Request) admissi
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	// TODO: Remove namespace population once support for k8s <1.24 is dropped
-	// Ref: https://github.com/kubernetes/kubernetes/pull/94637
-	if pod.GetNamespace() == "" {
-		pod.SetNamespace(request.Namespace)
-	}
-
 	logger := h.logger.WithValues("pod", client.ObjectKeyFromObject(pod))
 
 	if err := h.validatePod(ctx, logger, pod); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:
Drop support for kubernetes < 1.24 for `shoot-lakom-service` extension.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/8405

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `shoot-lakom-service` extension no longer supports Shoots with Кubernetes version < 1.24.
```

