### PR TITLE
Update golang to 1.21.5

### DIFF
--- a/.test-defs/lifecycle.yaml
+++ b/.test-defs/lifecycle.yaml
@@ -19,4 +19,4 @@
 #     --shoot-name=$SHOOT_NAME
 #     --project-namespace=$PROJECT_NAMESPACE
 #     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-#   image: golang:1.21.4
+#   image: golang:1.21.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.21.4 AS builder
+FROM golang:1.21.5 AS builder
 
 ARG EFFECTIVE_VERSION
 ARG TARGETARCH


### PR DESCRIPTION
**What this PR does / why we need it**:
Update golang to 1.21.5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Lakom application and lakom extension controller are now built with Go version `1.21.5`.
```
