### PR TITLE
[release-v0.11] Automated cherry pick of #54: Fix mitigation for NoMatchingSignature error

### DIFF
--- a/pkg/lakom/verifysignature/verifier.go
+++ b/pkg/lakom/verifysignature/verifier.go
@@ -87,7 +87,7 @@ func verify(ctx context.Context, imageRef name.Reference, keys []crypto.PublicKe
 			}
 
 			if IsNoMatchingSignature(err) {
-				if errors.Is(err, context.Canceled) {
+				if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 					// Mitigation for https://github.com/gardener/gardener-extension-shoot-lakom-service/issues/25
 					// TODO(vpnachev): remove when https://github.com/sigstore/cosign/issues/3133 is fixed and vendored
 					return false, err

--- a/pkg/lakom/verifysignature/verifier.go
+++ b/pkg/lakom/verifysignature/verifier.go
@@ -90,6 +90,7 @@ func verify(ctx context.Context, imageRef name.Reference, keys []crypto.PublicKe
 				if errors.Is(ctx.Err(), context.Canceled) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
 					// Mitigation for https://github.com/gardener/gardener-extension-shoot-lakom-service/issues/25
 					// TODO(vpnachev): remove when https://github.com/sigstore/cosign/issues/3133 is fixed and vendored
+					log.Info("no matching signatures error detected as canceled or deadline exceeded context", "error", err)
 					return false, err
 				}
 


### PR DESCRIPTION
/area security
/kind bug

Cherry pick of #54 on release-v0.11.

#54: Fix mitigation for NoMatchingSignature error

**Release Notes:**
```bugfix operator
Fix a bug in the mitigation for wrongly cached image signatures verification results due to exceeded or canceled context. 
```