### PR TITLE
[release-v0.11] Automated cherry pick of #57: Update golang to 1.21.5

### DIFF
--- a/.test-defs/lifecycle.yaml
+++ b/.test-defs/lifecycle.yaml
@@ -19,4 +19,4 @@
 #     --shoot-name=$SHOOT_NAME
 #     --project-namespace=$PROJECT_NAMESPACE
 #     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
-#   image: golang:1.21.4
+#   image: golang:1.21.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.21.4 AS builder
+FROM golang:1.21.5 AS builder
 
 ARG EFFECTIVE_VERSION
 ARG TARGETARCH


### PR DESCRIPTION
/area dev-productivity
/kind task

Cherry pick of #57 on release-v0.11.

#57: Update golang to 1.21.5

**Release Notes:**
```other operator
Lakom application and lakom extension controller are now built with Go version `1.21.5`.
```