### PR TITLE
Verify all images for managedseed

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -593,7 +593,7 @@ func getSeedResources(lakomReplicas *int32, namespace, genericKubeconfigName, sh
 	return resources, nil
 }
 
-func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessServiceAccountName, shootNamespace string) (map[string][]byte, error) {
+func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessServiceAccountName, projectNamespace string) (map[string][]byte, error) {
 	var (
 		matchPolicy          = admissionregistration.Equivalent
 		sideEffectClass      = admissionregistration.SideEffectClassNone
@@ -622,7 +622,7 @@ func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessSe
 		}}
 	)
 
-	isManagedSeed := shootNamespace == v1beta1constants.GardenNamespace
+	isManagedSeed := projectNamespace == v1beta1constants.GardenNamespace
 	if !isManagedSeed {
 		objectSelector = metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -158,7 +158,6 @@ func (a *actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 		return err
 	}
 
-	logger.Info("Shoot namespace: ", "namespace", cluster.Shoot.GetNamespace())
 	shootResources, err := getShootResources(
 		caBundleSecret.Data[secretutils.DataKeyCertificateBundle],
 		namespace,

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -613,7 +613,7 @@ func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessSe
 			},
 		}
 		objectSelector = metav1.LabelSelector{}
-		rules = []admissionregistration.RuleWithOperations{{
+		rules          = []admissionregistration.RuleWithOperations{{
 			Operations: []admissionregistration.OperationType{admissionregistration.Create, admissionregistration.Update},
 			Rule: admissionregistration.Rule{
 				APIGroups:   []string{""},


### PR DESCRIPTION
**What this PR does / why we need it**:
When a shoot is a managed seed cluster, all of the resources in the kube-system namespace need to be validated and not only those that are labeled with `managed-by: gardener`.

With this change, if the shoot is a managed seed (determined by checking if it is in the garden namespace) the selector for `managed-by: gardener` won't be used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Note that this method for handling the case where the cluster is a managed seed will most likely be changed/updated in the near future. 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
All pods in Managed Seed clusters will now be validated for trusted image signatures.
```
