### PR TITLE
Migrate away from deprecated golangci config option

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,9 +2,6 @@ run:
   concurrency: 4
   deadline: 10m
 
-  skip-files:
-  - "zz_generated\\..*\\.go$"
-
 linters:
   enable:
   - gocritic
@@ -23,3 +20,5 @@ issues:
   - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
   - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
   - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
+  exclude-files:
+  - "zz_generated\\..*\\.go$"


### PR DESCRIPTION
**What this PR does / why we need it**:
Migrate away from deprecated golangci config option

/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
