### PR TITLE
Reduce resource demands of lakom container

### DIFF
--- a/charts/lakom/templates/vpa.yaml
+++ b/charts/lakom/templates/vpa.yaml
@@ -10,13 +10,11 @@ metadata:
   name: {{ .Values.name }}
   namespace: {{ .Release.Namespace }}
 spec:
-  {{- if .Values.vpa.resourcePolicy }}
   resourcePolicy:
     containerPolicies:
-    - containerName: '*'
-      minAllowed:
-        memory: {{ required ".Values.vpa.resourcePolicy.minAllowed.memory is required" .Values.vpa.resourcePolicy.minAllowed.memory }}
-  {{- end }}
+    - containerName:  {{ .Values.name }}
+      controlledResources:
+      - memory
   targetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/charts/lakom/values.yaml
+++ b/charts/lakom/values.yaml
@@ -12,8 +12,7 @@ image:
 replicaCount: 3
 resources:
   requests:
-    cpu: 100m
-    memory: 128Mi
+    memory: 25M
 metricsPort: 8080
 healthPort: 8081
 serverPort: 10250
@@ -59,9 +58,6 @@ priorityClass:
   name: lakom-system
 vpa:
   enabled: true
-  resourcePolicy:
-    minAllowed:
-      memory: 64Mi
   updatePolicy:
     updateMode: "Auto"
 additionalAnnotations:

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -286,8 +286,7 @@ func getSeedResources(lakomReplicas *int32, namespace, genericKubeconfigName, sh
 		lakomConfigConfigMapName = constants.ExtensionServiceName + "-lakom-config"
 		webhookTLSCertDir        = "/etc/lakom/tls"
 		registry                 = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
-		requestCPU               = resource.MustParse("50m")
-		requestMemory            = resource.MustParse("64Mi")
+		requestMemory            = resource.MustParse("25M")
 		vpaUpdateMode            = vpaautoscalingv1.UpdateModeAuto
 	)
 
@@ -400,7 +399,6 @@ func getSeedResources(lakomReplicas *int32, namespace, genericKubeconfigName, sh
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    requestCPU,
 								corev1.ResourceMemory: requestMemory,
 							},
 						},
@@ -520,8 +518,8 @@ func getSeedResources(lakomReplicas *int32, namespace, genericKubeconfigName, sh
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
 							ContainerName: constants.ApplicationName,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							ControlledResources: &[]corev1.ResourceName{
+								corev1.ResourceMemory,
 							},
 						},
 					},

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -488,8 +488,7 @@ spec:
           initialDelaySeconds: 5
         resources:
           requests:
-            cpu: 50m
-            memory: 64Mi
+            memory: 25M
         volumeMounts:
         - mountPath: /etc/lakom/config
           name: lakom-config
@@ -637,8 +636,8 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: lakom
-      minAllowed:
-        memory: 32Mi
+      controlledResources:
+      - memory
   targetRef:
     apiVersion: apps/v1
     kind: Deployment

--- a/pkg/controller/seed/reconciler.go
+++ b/pkg/controller/seed/reconciler.go
@@ -192,8 +192,7 @@ func getResources(serverTLSSecretName, image, lakomConfig string, webhookCaBundl
 		lakomConfigConfigMapName = constants.SeedExtensionServiceName + "-lakom-config"
 		webhookTLSCertDir        = "/etc/lakom/tls"
 		registry                 = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
-		requestCPU               = resource.MustParse("50m")
-		requestMemory            = resource.MustParse("64Mi")
+		requestMemory            = resource.MustParse("25M")
 		vpaUpdateMode            = vpaautoscalingv1.UpdateModeAuto
 		kubeSystemNamespace      = metav1.NamespaceSystem
 		matchPolicy              = admissionregistration.Equivalent
@@ -327,7 +326,6 @@ func getResources(serverTLSSecretName, image, lakomConfig string, webhookCaBundl
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    requestCPU,
 								corev1.ResourceMemory: requestMemory,
 							},
 						},
@@ -442,8 +440,8 @@ func getResources(serverTLSSecretName, image, lakomConfig string, webhookCaBundl
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 						{
 							ContainerName: constants.SeedApplicationName,
-							MinAllowed: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("32Mi"),
+							ControlledResources: &[]corev1.ResourceName{
+								corev1.ResourceMemory,
 							},
 						},
 					},

--- a/pkg/controller/seed/reconciler_test.go
+++ b/pkg/controller/seed/reconciler_test.go
@@ -411,8 +411,7 @@ spec:
           initialDelaySeconds: 5
         resources:
           requests:
-            cpu: 50m
-            memory: 64Mi
+            memory: 25M
         volumeMounts:
         - mountPath: /etc/lakom/config
           name: lakom-config
@@ -541,8 +540,8 @@ spec:
   resourcePolicy:
     containerPolicies:
     - containerName: lakom-seed
-      minAllowed:
-        memory: 32Mi
+      controlledResources:
+      - memory
   targetRef:
     apiVersion: apps/v1
     kind: Deployment


### PR DESCRIPTION
**What this PR does / why we need it**:
Reduce resource demands of lakom container as requested by @vlerenc:

> Given the stats below, can we please make the following changes:
> 
> - [ ] Memory requests changed from 64Mi to 25M as that's the 5th percentile of memory usage (generally used as initial requests unless there are good reasons to deviate)
> - [ ] CPU requests of 50m dropped (CPU usage is so low, that it actually isn't worth putting it under VPA and accepting the waste (VPA cannot recommend values below 10m/10M) and disruptions)
> - [ ] Vertical scaling on CPU dropped in VPA resource (see controlledResources ref1 and ref2) (consequently, we can/must drop CPU from VPA to keep CPU requests out of the pods)
> - [ ] minAllowed of 32Mi dropped (the average memory consumption is even lower than 32Mi, so we are wasting resources)


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Lakom container resource demands have been reduced:
- memory requests reduced from 64Mi to 25M
- CPU requests have been dropped
- Vertical scaling on CPU requests dropped
- minAllowed of 32Mi memory dropped
```
