### PR TITLE
Verify Images/Charts for Pods, ControllerDeployments, Gardenlets & operator.Extensions

### DIFF
--- a/pkg/lakom/resolvetag/admission.go
+++ b/pkg/lakom/resolvetag/admission.go
@@ -164,7 +164,11 @@ func (h *handler) Handle(ctx context.Context, request admission.Request) admissi
 func (h *handler) handlePod(ctx context.Context, p *corev1.Pod, logger logr.Logger) error {
 	logger.Info("Handling new pod request")
 
-	kcr := utils.NewLazyKeyChainReaderFromPod(ctx, h.reader, p, h.useOnlyImagePullSecrets)
+	var secretNames []string
+	for _, ips := range p.Spec.ImagePullSecrets {
+		secretNames = append(secretNames, ips.Name)
+	}
+	kcr := utils.NewLazyKeyChainReaderFromPod(ctx, h.reader, p.Namespace, secretNames, h.useOnlyImagePullSecrets)
 
 	for idx, ic := range p.Spec.InitContainers {
 		image, err := h.handleContainer(ctx, ic.Image, kcr, logger.WithValues("initContainer", ic.Name))

--- a/pkg/lakom/utils/utils.go
+++ b/pkg/lakom/utils/utils.go
@@ -42,13 +42,13 @@ func NewLazyKeyChainReader(reader func() (authn.Keychain, error)) *lazyKeyChainR
 }
 
 // NewLazyKeyChainReaderFromPod creates lazyKeyChainReader for given pod.
-func NewLazyKeyChainReaderFromPod(ctx context.Context, c client.Reader, pod *corev1.Pod, useOnlyImagePullSecrets bool) *lazyKeyChainReader {
+func NewLazyKeyChainReaderFromPod(ctx context.Context, c client.Reader, namespace string, secretNames []string, useOnlyImagePullSecrets bool) *lazyKeyChainReader {
 	return NewLazyKeyChainReader(
 		func() (authn.Keychain, error) {
-			var imagePullSecrets = make([]corev1.Secret, len(pod.Spec.ImagePullSecrets))
-			for _, sn := range pod.Spec.ImagePullSecrets {
+			var imagePullSecrets = make([]corev1.Secret, len(secretNames))
+			for _, sn := range secretNames {
 				secret := &corev1.Secret{}
-				secretKey := client.ObjectKey{Namespace: pod.GetNamespace(), Name: sn.Name}
+				secretKey := client.ObjectKey{Namespace: namespace, Name: sn}
 
 				if err := c.Get(ctx, secretKey, secret); err != nil {
 					if apierrors.IsNotFound(err) {


### PR DESCRIPTION

Handling of the admission request now passes the request through a layer that generates a list of generic targets for verification.

This way, we can reuse the existing verification logic.

**What this PR does / why we need it**:
Verification of helm charts is required. 

**Which issue(s) this PR fixes**:
Fixes #97 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
