### PR TITLE
Skaffold Fix

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ---
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: extension
@@ -91,9 +91,18 @@ manifests:
     paths:
       - local-setup
 deploy:
-  kubectl: {}
+  # --server-side apply is a workaround for https://github.com/gardener/gardener/issues/10267.
+  # kubectl apply attempts a strategic merge patch which fails for a ControllerDeployment.
+  # For more details, see https://github.com/gardener/gardener/issues/10267.
+  #
+  # TODO: Switch back to "kubectl: {}" when the above issue is resolved.
+  kubectl:
+    flags:
+      apply:
+        - --server-side
+        - --force-conflicts
 ---
-apiVersion: skaffold/v4beta3
+apiVersion: skaffold/v4beta7
 kind: Config
 metadata:
   name: admission


### PR DESCRIPTION
**What this PR does / why we need it**:
 kubectl apply attempts a strategic merge patch which fails for a ControllerDeployment.
 For more details, see https://github.com/gardener/gardener/issues/10267.

**Which issue(s) this PR fixes**:
Fixes #120 partly

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
