### PR TITLE
Fake registry for tests

### DIFF
--- a/docs/oci_registries.md
+++ b/docs/oci_registries.md
@@ -1,4 +1,4 @@
-# Crash Course on OCI Registries
+# OCI Registries
 
 This document aims to introduce the reader to the general architecture of OCI
 Registries, their history and jargon that might be encountered.

--- a/docs/oci_registries.md
+++ b/docs/oci_registries.md
@@ -145,7 +145,7 @@ version of this objest is the one that gets stored and gets used for
 verification. 
 
 Storage of the signature is done via an image manifest that gets uploaded
-in the same repo as the image, but tagged with `<image-digest>.sig`.
+in the same repo as the image, but tagged with `sha256-<container-image-digest>.sig`.
 Thus, the signature discovery mechanism is to just fetch the image digest 
 that is tagged with the aforementioned tag.
 

--- a/docs/oci_registries_crash_course.md
+++ b/docs/oci_registries_crash_course.md
@@ -55,15 +55,15 @@ it can be stored only once and referenced by multiple images.
 
 ### Manifests
 
-A manifest is just a JSON document. It is stored seperately from the blobs.
+A manifest is just a JSON document. It is stored separately from the blobs.
 But similarly to the blobs, it is also content addressable. The manifest gets
-formated to a canonical form and then hashed. The hash becomes the address of
+formatted to a canonical form and then hashed. The hash becomes the address of
 the manifest.
 
 Where manifests become powerful is when they are used to reference to other
 manifests or blobs. These references are called [OCI Content Descriptors](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md).
-For example, the Image Manifest that most readers would be familiar with containes
-a lisf of layers that are used to build the image. Each layer is a reference to
+For example, the Image Manifest that most readers would be familiar with contains
+a list of layers that are used to build the image. Each layer is a reference to
 a blob.
 
 An additional reference outside the layer references is used for storing 
@@ -71,7 +71,7 @@ additional configuration. More info can be found in the official [OCI Image Mani
 
 The term _artifact_ is just a generalization over the Image Manifest idea.
 The Image Manifest has a specific format that can be found in the aforementioned [OCI Image Manifest spec](https://github.com/opencontainers/image-spec/blob/v1.0.1/manifest.md).
-The important field is the .config.mediaType field. Based on the official guidelines,
+The important field is the `.config.mediaType` field. Based on the official guidelines,
 it can be used for defining types other than an image. More info can be found [here](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage).
 
 Combining all of these ideas, we can see that artifacts can be represented by 1 
@@ -93,7 +93,7 @@ to address them in a human-readable format. Tags allow us to add a reference
 to a given manifest that differs from the digest of the object.
 
 Normally, whenever we push an image to a registry, if we don't give it an
-explicit tag, the registry would most likey give it the tag `latest`. This,
+explicit tag, the registry would most likely give it the tag `latest`. This,
 actually is not mandatory based on the distribution spec. Manifests don't 
 require that they have a tag.
 

--- a/docs/oci_registries_crash_course.md
+++ b/docs/oci_registries_crash_course.md
@@ -1,0 +1,115 @@
+# Crash Course on OCI Registries
+
+This document aims to introduce the reader to the general architecture of OCI
+Registries, their history and jargon that might be encountered.
+
+## History of Container Registries
+
+Most readers might be familiar with the container registry that was introduced
+by Docker. It aims to provide a way for developers to store and distribute
+container images that can be used for running applications in containers.
+
+In the beginning, the registry was meant to only host images in a way that the
+different layers of the image could be downloaded in parallel, while being 
+assembled on the client side.
+
+In June 2015, multiple companies agreed to standardize the container image format,
+including its distribution and runtime. This was the birth of the Open Container
+Initiative (OCI). 
+
+
+## Understanding OCI Registries
+
+The most important document that pertains to OCI Registries in the case of Lakom is the [OCI 
+distribution spec](https://github.com/opencontainers/distribution-spec/blob/main/spec.md). 
+It outlines the way that artifacts shall be stored and fetched from a registry 
+that adheres to the OCI standard. 
+
+OCI Registries are meant to store _content_. While in the beginning the main
+problem that they were trying to solve was image storage, during the evolution
+of the image registry concept, a decision was made to make it more general
+for storage of any form of objects, sometimes called _artifacts_.
+
+An artifact is an abstract idea of multiple components that together describe
+how an object is built along with storing metadata about the object.
+
+To implement this, every OCI registry has to expose an API for creating
+3 types of objects:
+- Blobs
+- Manifests
+- Tags
+
+
+### Blobs
+
+A blob is just a set of bytes. Nothing more. The important part about blobs
+is that they are _content addressable_. [Content Addressable Storage (CAS)](https://en.wikipedia.org/wiki/Content-addressable_storage)
+is a method of storing data in such a way that the address of the data is derived
+from the data itself. This means that if you store the same blob twice, it will
+be stored only once, and the address of the blob will be the same. This is achieved
+by using the [digest](https://en.wikipedia.org/wiki/Cryptographic_hash_function) of the blob as the address.
+
+This is the actual mechanism for allowing images to be optimal in terms of storage.
+Since most images begin by depending on the same base image, this means that
+it can be stored only once and referenced by multiple images.
+
+### Manifests
+
+A manifest is just a JSON document. It is stored seperately from the blobs.
+But similarly to the blobs, it is also content addressable. The manifest gets
+formated to a canonical form and then hashed. The hash becomes the address of
+the manifest.
+
+Where manifests become powerful is when they are used to reference to other
+manifests or blobs. These references are called [OCI Content Descriptors](https://github.com/opencontainers/image-spec/blob/v1.0.1/descriptor.md).
+For example, the Image Manifest that most readers would be familiar with containes
+a lisf of layers that are used to build the image. Each layer is a reference to
+a blob.
+
+An additional reference outside the layer references is used for storing 
+additional configuration. More info can be found in the official [OCI Image Manifest spec](https://github.com/opencontainers/image-spec/blob/v1.0.1/manifest.md).
+
+The term _artifact_ is just a generalization over the Image Manifest idea.
+The Image Manifest has a specific format that can be found in the aforementioned [OCI Image Manifest spec](https://github.com/opencontainers/image-spec/blob/v1.0.1/manifest.md).
+The important field is the .config.mediaType field. Based on the official guidelines,
+it can be used for defining types other than an image. More info can be found [here](https://github.com/opencontainers/image-spec/blob/main/manifest.md#guidelines-for-artifact-usage).
+
+Combining all of these ideas, we can see that artifacts can be represented by 1 
+specific object - a manifest. That manifest, based on the media type in the config, can be 
+interpreted by different programs for their specific use case. Eg. a Helm chart.
+Helm charts specifically have a mediaType of `application/vnd.cncf.helm.config.v1+json`.
+Layers, too, have a media type. The media type of a layer when the artifact
+is a helm chart is one of:
+- application/vnd.cncf.helm.config.v1+json
+- application/vnd.cncf.helm.chart.content.v1.tar+gzip
+- application/vnd.cncf.helm.chart.provenance.v1.prov
+
+More info specifically on Helm charts as OCI Artifacts can be found here: [Helm OCI MediaTypes](https://helm.sh/blog/helm-oci-mediatypes/).
+
+### Tags
+
+While manifests and blobs being content addressable is nice, it becomes hard
+to address them in a human-readable format. Tags allow us to add a reference
+to a given manifest that differs from the digest of the object.
+
+Normally, whenever we push an image to a registry, if we don't give it an
+explicit tag, the registry would most likey give it the tag `latest`. This,
+actually is not mandatory based on the distribution spec. Manifests don't 
+require that they have a tag.
+
+Multiple tags can point to the same manifest.
+
+### Cosign
+
+Cosign is generally a part of the bigger project called [sigstore](https://sigstore.dev/).
+Sigstore is an "open-source project for improving software supply chain security".
+It aims for developers to have a hassle-free way to sign their artifacts while
+leveraging other components that add additional layers of security to the
+signature process. Eg. Rekor and Fulcio.
+
+Cosign is a CLI tool aiming to tie all the components of sigstore together.
+In our specific case, we use it only as a format for creating signatures and 
+then verifying them. In theory, we wouldn't need to use Cosign for this, but
+it uses a popular format for the signatures and the libraries help us 
+save work.
+

--- a/pkg/lakom/resolvetag/admission_test.go
+++ b/pkg/lakom/resolvetag/admission_test.go
@@ -38,12 +38,6 @@ var (
 	apiReader *mockclient.MockReader
 )
 
-var _ = BeforeSuite(func() {
-	scheme = runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	Expect(err).ToNot(HaveOccurred())
-})
-
 var _ = Describe("Admission Handler", func() {
 	var (
 		ctx     = context.Background()
@@ -92,6 +86,20 @@ var _ = Describe("Admission Handler", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		handler = h
+
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "pod-namespace",
+				Name:      "pod-name",
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{{
+					Name:  "container",
+					Image: signedImageTagRef,
+				}},
+			},
+		}
+		imageDigest = signedImageFullRef
 	})
 
 	DescribeTable(

--- a/pkg/lakom/resolvetag/admission_test.go
+++ b/pkg/lakom/resolvetag/admission_test.go
@@ -29,8 +29,6 @@ import (
 var (
 	deploymentGVK = metav1.GroupVersionKind{Group: "apps", Kind: "Deployment", Version: "v1"}
 	podGVK        = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
-	imageTag      = "registry.k8s.io/pause:3.7"
-	imageDigest   = "registry.k8s.io/pause@sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c" // #nosec G101
 )
 
 var _ = Describe("Admission Handler", func() {
@@ -82,7 +80,6 @@ var _ = Describe("Admission Handler", func() {
 
 		handler = h
 		pod.Spec.Containers[0].Image = signedImageTagRef
-		imageDigest = signedImageFullRef
 	})
 
 	DescribeTable(
@@ -113,7 +110,7 @@ var _ = Describe("Admission Handler", func() {
 		patch := response.Patches[0]
 		Expect(patch.Operation).To(Equal("replace"))
 		Expect(patch.Path).To(Equal("/spec/containers/0/image"))
-		Expect(patch.Value).To(Equal(imageDigest))
+		Expect(patch.Value).To(Equal(signedImageFullRef))
 	})
 
 })

--- a/pkg/lakom/resolvetag/admission_test.go
+++ b/pkg/lakom/resolvetag/admission_test.go
@@ -81,19 +81,7 @@ var _ = Describe("Admission Handler", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		handler = h
-
-		pod = &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "pod-namespace",
-				Name:      "pod-name",
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:  "container",
-					Image: signedImageTagRef,
-				}},
-			},
-		}
+		pod.Spec.Containers[0].Image = signedImageTagRef
 		imageDigest = signedImageFullRef
 	})
 

--- a/pkg/lakom/resolvetag/admission_test.go
+++ b/pkg/lakom/resolvetag/admission_test.go
@@ -31,11 +31,6 @@ var (
 	podGVK        = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
 	imageTag      = "registry.k8s.io/pause:3.7"
 	imageDigest   = "registry.k8s.io/pause@sha256:bb6ed397957e9ca7c65ada0db5c5d1c707c9c8afc80a94acbe69f3ae76988f0c" // #nosec G101
-
-	scheme    *runtime.Scheme
-	ctrl      *gomock.Controller
-	mgr       *mockmanager.MockManager
-	apiReader *mockclient.MockReader
 )
 
 var _ = Describe("Admission Handler", func() {
@@ -51,7 +46,7 @@ var _ = Describe("Admission Handler", func() {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name:  "container",
-					Image: imageTag,
+					Image: signedImageTagRef,
 				}},
 			},
 		}

--- a/pkg/lakom/resolvetag/resolver_test.go
+++ b/pkg/lakom/resolvetag/resolver_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Resolver", func() {
 			Entry("Do not run actual resolving of image with digest", &signedImageFullRef, &signedImageFullRef, true, false, ""),
 			Entry("Fail to parse bad image digest", ptr.To("gardener/non-existing-image@sha256:123"), ptr.To(""), true, false, "repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`"),
 			Entry("Fail to parse bad image tag", ptr.To("gardener/non-existing-image:123!"), ptr.To(""), true, false, "tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`"),
-			Entry("Fail to get non-existing image", &nonExistantImageTagRef, ptr.To(""), false, true, "unexpected status code 404 Not Found"),
+			Entry("Fail to get non-existing image", &nonExistentImageTagRef, ptr.To(""), false, true, "unexpected status code 404 Not Found"),
 		)
 	})
 
@@ -106,7 +106,7 @@ var _ = Describe("Resolver", func() {
 			Entry("Do not run actual resolving of image with digest", &signedImageFullRef, &signedImageFullRef, true, false, ""),
 			Entry("Fail to parse bad image digest", ptr.To("gardener/non-existing-image@sha256:123"), ptr.To(""), true, false, "repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`"),
 			Entry("Fail to parse bad image tag", ptr.To("gardener/non-existing-image:123!"), ptr.To(""), true, false, "tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`"),
-			Entry("Fail to get non-existing image", &nonExistantImageTagRef, ptr.To(""), false, true, "unexpected status code 404 Not Found"),
+			Entry("Fail to get non-existing image", &nonExistentImageTagRef, ptr.To(""), false, true, "unexpected status code 404 Not Found"),
 		)
 
 		It("Should uses the cache to resolve the image", func() {

--- a/pkg/lakom/resolvetag/resolver_test.go
+++ b/pkg/lakom/resolvetag/resolver_test.go
@@ -10,12 +10,12 @@ import (
 
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/resolvetag"
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/utils"
-	"k8s.io/utils/ptr"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/utils/ptr"
 )
 
 type anonymousKeyChain struct{}

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -18,6 +18,8 @@ import (
 	"os"
 	"testing"
 
+	mockclient "github.com/gardener/gardener/third_party/mock/controller-runtime/client"
+	mockmanager "github.com/gardener/gardener/third_party/mock/controller-runtime/manager"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	registryv1 "github.com/google/go-containerregistry/pkg/v1"
@@ -31,6 +33,7 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
 	"github.com/sigstore/sigstore/pkg/signature"
+	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -52,6 +55,11 @@ var (
 
 	// Public key in PEM format for verifying signatures in the fake registry
 	publicKey string
+
+	scheme    *runtime.Scheme
+	ctrl      *gomock.Controller
+	mgr       *mockmanager.MockManager
+	apiReader *mockclient.MockReader
 )
 
 const (

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -95,17 +95,14 @@ var _ = BeforeSuite(func() {
 	privateKey, err := cosign.GeneratePrivateKey()
 	Expect(err).ToNot(HaveOccurred())
 
-	err = signImage(signedImage, signedImageFullRef, privateKey)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(signImage(signedImage, signedImageFullRef, privateKey)).ToNot(HaveOccurred())
 })
 
 func startRegistry() (*url.URL, *httptest.Server) {
 	ginkgoLogger := log.New(GinkgoWriter, "", 0)
 	s := httptest.NewServer(registry.New(registry.Logger(ginkgoLogger)))
 	u, err := url.Parse(s.URL)
-	if err != nil {
-		log.Fatal("Error parsing")
-	}
+	Expect(err).ToNot(HaveOccurred())
 
 	return u, s
 }
@@ -125,8 +122,7 @@ func createTestImage(registryURL *url.URL, tag string) (registryv1.Image, name.R
 	}
 
 	// Write image to registry
-	err = remote.Write(tagRef, i)
-	if err != nil {
+	if err = remote.Write(tagRef, i); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -133,8 +133,7 @@ func publicKeyToPEM(pub crypto.PublicKey) (string, error) {
 	}
 
 	// Encode the PEM block to a string
-	var pemBytes []byte
-	pemBytes = pem.EncodeToMemory(pemBlock)
+	pemBytes := pem.EncodeToMemory(pemBlock)
 
 	return string(pemBytes), nil
 }
@@ -161,6 +160,9 @@ func writeRandomImage(tag string) (registryv1.Image, name.Reference, error) {
 
 	// Get digest
 	headResponse, err := remote.Head(tagRef)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	// TODO(rado): There should be an easier way than this
 	fullRef := tagRef.Context().Name() + "@" + headResponse.Digest.String()

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -18,18 +18,16 @@ import (
 	"os"
 	"testing"
 
-	ociRemote "github.com/sigstore/cosign/v2/pkg/oci/remote"
-
+	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/registry"
 	registryv1 "github.com/google/go-containerregistry/pkg/v1"
-
-	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/random"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
+	ociRemote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
 	"github.com/sigstore/sigstore/pkg/signature"

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -5,13 +5,207 @@
 package resolvetag_test
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"testing"
 
+	ociRemote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
+	"github.com/sigstore/cosign/v2/pkg/oci/signed"
+	"github.com/sigstore/cosign/v2/pkg/oci/static"
+	"github.com/sigstore/sigstore/pkg/signature"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	// Fake registry properties
+	registryURL *url.URL
+	server      *httptest.Server
+
+	signedImageFullRef   string
+	unsignedImageFullRef string
+
+	signedImageTagRef      string
+	unsignedImageTagRef    string
+	nonExistantImageTagRef string
+
+	// Key for signing images in fake registry
+	privateKey *ecdsa.PrivateKey
+
+	// Public key in PEM format for verifying signatures in the fake registry
+	publicKey string
+)
+
+const (
+	signedImageTag   = "signed"
+	unsignedImageTag = "unsigned"
 )
 
 func TestCMD(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ResolveTag Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	Expect(err).ToNot(HaveOccurred())
+
+	dirPath, err := os.MkdirTemp("", "verifysignature_test")
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		err := os.RemoveAll(dirPath)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Tests rely on a fake registry
+	registryURL, server = startFakeRegistry()
+	DeferCleanup(func() {
+		server.Close()
+	})
+
+	signedImage, signedImageRef, err := writeRandomImage(signedImageTag)
+	Expect(err).ToNot(HaveOccurred())
+	_, unsignedImageRef, err := writeRandomImage(unsignedImageTag)
+	Expect(err).ToNot(HaveOccurred())
+
+	signedImageFullRef = signedImageRef.Name()
+	unsignedImageFullRef = unsignedImageRef.Name()
+
+	signedImageTagRef = signedImageRef.Context().Tag(signedImageTag).String()
+	unsignedImageTagRef = unsignedImageRef.Context().Tag(unsignedImageTag).String()
+
+	nonExistantImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
+
+	privateKey, err = cosign.GeneratePrivateKey()
+	Expect(err).ToNot(HaveOccurred())
+	publicKey, err = publicKeyToPEM(privateKey.Public())
+	Expect(err).ToNot(HaveOccurred())
+
+	err = signImage(signedImage, signedImageFullRef)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	server.Close()
+})
+
+func startFakeRegistry() (*url.URL, *httptest.Server) {
+	nopLog := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(nopLog)))
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		log.Fatal("Error parsing")
+	}
+
+	return u, s
+}
+
+func publicKeyToPEM(pub crypto.PublicKey) (string, error) {
+	// Marshal the public key to DER format
+	derBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a PEM block
+	pemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}
+
+	// Encode the PEM block to a string
+	var pemBytes []byte
+	pemBytes = pem.EncodeToMemory(pemBlock)
+
+	return string(pemBytes), nil
+}
+
+func writeRandomImage(tag string) (registryv1.Image, name.Reference, error) {
+	// Create image
+	i, err := random.Image(512, 1)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Create tag
+	tagName := fmt.Sprintf("%s/%s:%s", registryURL.Host, "test", tag)
+	tagRef, err := name.NewTag(tagName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Write image to registry
+	err = remote.Write(tagRef, i)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Get digest
+	headResponse, err := remote.Head(tagRef)
+
+	// TODO(rado): There should be an easier way than this
+	fullRef := tagRef.Context().Name() + "@" + headResponse.Digest.String()
+
+	reference, err := name.ParseReference(fullRef)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return i, reference, nil
+}
+
+func signImage(image registryv1.Image, imageFullRef string) error {
+	digest, err := name.NewDigest(imageFullRef)
+	if err != nil {
+		return err
+	}
+
+	signerVerifier, err := signature.LoadSignerVerifier(privateKey, crypto.SHA256)
+	if err != nil {
+		return err
+	}
+
+	payload, signature, err := signature.SignImage(signerVerifier, digest, nil)
+	if err != nil {
+		return err
+	}
+
+	ociSignature, err := static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature))
+	if err != nil {
+		return err
+	}
+
+	si := signed.Image(image)
+	si, err = mutate.AttachSignatureToImage(si, ociSignature)
+	if err != nil {
+		return err
+	}
+
+	err = ociRemote.WriteSignatures(digest.Context(), si)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -7,6 +7,8 @@ package resolvetag_test
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"log"
@@ -24,7 +26,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
 	ociRemote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
@@ -92,7 +93,7 @@ var _ = BeforeSuite(func() {
 
 	nonExistentImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
 
-	privateKey, err := cosign.GeneratePrivateKey()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	Expect(err).ToNot(HaveOccurred())
 
 	Expect(signImage(signedImage, signedImageFullRef, privateKey)).ToNot(HaveOccurred())

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -36,12 +36,14 @@ import (
 )
 
 var (
+	// FullRef use the digest instead of the tag.
 	signedImageFullRef   string
 	unsignedImageFullRef string
 
+	// TagRef use the tag instead of the digest for referencing the artifact.
 	signedImageTagRef      string
 	unsignedImageTagRef    string
-	nonExistantImageTagRef string
+	nonExistentImageTagRef string
 
 	scheme    *runtime.Scheme
 	ctrl      *gomock.Controller
@@ -88,7 +90,7 @@ var _ = BeforeSuite(func() {
 	signedImageTagRef = signedImageRef.Context().Tag(signedImageTag).String()
 	unsignedImageTagRef = unsignedImageRef.Context().Tag(unsignedImageTag).String()
 
-	nonExistantImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
+	nonExistentImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
 
 	privateKey, err := cosign.GeneratePrivateKey()
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/lakom/verifysignature/admission_test.go
+++ b/pkg/lakom/verifysignature/admission_test.go
@@ -74,9 +74,8 @@ var _ = Describe("Admission Handler", func() {
 		cosignConfig = lakomconfig.Config{
 			PublicKeys: []lakomconfig.Key{
 				{
-					Name:      "test",
-					Key:       publicKey,
-					Algorithm: "",
+					Name: "test",
+					Key:  publicKey,
 				},
 			},
 		}

--- a/pkg/lakom/verifysignature/admission_test.go
+++ b/pkg/lakom/verifysignature/admission_test.go
@@ -92,22 +92,7 @@ var _ = Describe("Admission Handler", func() {
 		Expect(err).ToNot(HaveOccurred())
 		handler = h
 
-		// TODO(rado): This reinialization is very annoying. Find a way to avoid it.
-		// It's currently needed since the `signedImageTag` is initialized after
-		// sped Ginkgo spec tree is built. While the `BeforeSuite` function is called
-		// after the spec tree is built buf before the spec is ran.
-		pod = &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "pod-namespace",
-				Name:      "pod-name",
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{{
-					Name:  "container",
-					Image: signedImageFullRef,
-				}},
-			},
-		}
+		pod.Spec.Containers[0].Image = signedImageFullRef
 	})
 
 	DescribeTable(

--- a/pkg/lakom/verifysignature/admission_test.go
+++ b/pkg/lakom/verifysignature/admission_test.go
@@ -30,10 +30,6 @@ import (
 var (
 	deploymentGVK = metav1.GroupVersionKind{Group: "apps", Kind: "Deployment", Version: "v1"}
 	podGVK        = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
-
-	ctrl      *gomock.Controller
-	mgr       *mockmanager.MockManager
-	apiReader *mockclient.MockReader
 )
 
 var _ = Describe("Admission Handler", func() {
@@ -50,7 +46,7 @@ var _ = Describe("Admission Handler", func() {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name:  "container",
-					Image: signedImageTag,
+					Image: signedImageFullRef,
 				}},
 			},
 		}
@@ -108,7 +104,7 @@ var _ = Describe("Admission Handler", func() {
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{{
 					Name:  "container",
-					Image: signedImageTag,
+					Image: signedImageFullRef,
 				}},
 			},
 		}

--- a/pkg/lakom/verifysignature/admission_test.go
+++ b/pkg/lakom/verifysignature/admission_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"os"
 	"time"
 
 	lakomconfig "github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/config"
@@ -48,24 +47,10 @@ IqozONbbdbqz11hlRJy9c7SG+hdcFl9jE9uE/dwtuwU2MqU9T/cN0YkWww==
 		},
 	}
 
-	scheme    *runtime.Scheme
 	ctrl      *gomock.Controller
 	mgr       *mockmanager.MockManager
 	apiReader *mockclient.MockReader
 )
-
-var _ = BeforeSuite(func() {
-	scheme = runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	Expect(err).ToNot(HaveOccurred())
-
-	dirPath, err := os.MkdirTemp("", "verifysignature_test")
-	Expect(err).ToNot(HaveOccurred())
-	DeferCleanup(func() {
-		err := os.RemoveAll(dirPath)
-		Expect(err).ToNot(HaveOccurred())
-	})
-})
 
 var _ = Describe("Admission Handler", func() {
 	var (

--- a/pkg/lakom/verifysignature/admission_test.go
+++ b/pkg/lakom/verifysignature/admission_test.go
@@ -30,7 +30,6 @@ import (
 var (
 	deploymentGVK = metav1.GroupVersionKind{Group: "apps", Kind: "Deployment", Version: "v1"}
 	podGVK        = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
-	imageDigest   = "gcr.io/projectsigstore/cosign@sha256:f9fd5a287a67f4b955d08062a966df10f9a600b6b8583fd367bce3f1f000a429"
 
 	ctrl      *gomock.Controller
 	mgr       *mockmanager.MockManager

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -127,9 +127,9 @@ var _ = Describe("Verifier", func() {
 		var (
 			cache          verifysignature.SignatureVerificationResultCache
 			cachedVerifier verifysignature.Verifier
-			err            error
 		)
 		BeforeEach(func() {
+			var err error
 			cache, err = verifysignature.NewSignatureVerificationResultCache(refresh, ttl)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -108,15 +108,15 @@ var _ = Describe("Verifier", func() {
 			Entry("Fail to parse bad image digest", ptr.To("gardener/non-existing-image@sha256:123"), false, true, "could not parse reference"),
 			Entry("Fail to parse bad image tag", ptr.To("gardener/non-existing-image:123!"), false, true, "could not parse reference"),
 			Entry("Refuse to verify image not using digest", ptr.To("registry.k8s.io/pause:3.7"), false, true, "image reference is not a digest"),
-			Entry("Successfully verify signed image", &signedImageTag, true, false, ""),
-			Entry("Fail signature check when image exists but it has not been signed", &nonSignedImageTag, false, false, ""),
+			Entry("Successfully verify signed image", &signedImageFullRef, true, false, ""),
+			Entry("Fail signature check when image exists but it has not been signed", &unsignedImageFullRef, false, false, ""),
 		)
 
 		It("Should fail image verification when context is canceled", func() {
 			canceledCtx, cancel := context.WithCancel(ctx)
 			cancel()
 
-			verified, err := directVerifier.Verify(canceledCtx, signedImageTag, kcr)
+			verified, err := directVerifier.Verify(canceledCtx, signedImageFullRef, kcr)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("context canceled"))
 			Expect(verified).To(BeFalse())
@@ -161,8 +161,8 @@ var _ = Describe("Verifier", func() {
 			Entry("Fail to parse bad image digest", ptr.To("gardener/non-existing-image@sha256:123"), false, true, "could not parse reference"),
 			Entry("Fail to parse bad image tag", ptr.To("gardener/non-existing-image:123!"), false, true, "could not parse reference"),
 			Entry("Refuse to verify image not using digest", ptr.To("registry.k8s.io/pause:3.7"), false, true, "image reference is not a digest"),
-			Entry("Successfully verify signed image", &signedImageTag, true, false, ""),
-			Entry("Fail signature check when image exists but it has not been signed", &nonSignedImageTag, false, false, ""),
+			Entry("Successfully verify signed image", &signedImageFullRef, true, false, ""),
+			Entry("Fail signature check when image exists but it has not been signed", &unsignedImageFullRef, false, false, ""),
 		)
 
 		It("Should not run real validation for cached result", func() {
@@ -182,7 +182,7 @@ var _ = Describe("Verifier", func() {
 			canceledCtx, cancel := context.WithCancel(ctx)
 			cancel()
 
-			image := nonSignedImageTag
+			image := unsignedImageFullRef
 			verified, err := cachedVerifier.Verify(canceledCtx, image, kcr)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("context canceled"))

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -84,16 +84,8 @@ var _ = Describe("Verifier", func() {
 		})
 
 		DescribeTable("Verify images",
-			// The image variable is a pointer to a string because for some unknown reason
-			// when a string variable is passed to the `Entry` function, a copy of the string object gets used
-			// rather than the original object.
-			//
-			// This means that if a string variable (maybe any type of variable?) is passed to the `Entry` function, it will be copied and
-			// subsequent changes to it will not be reflected in the test.
-			// Since `signedImageTag` gets declared first but initialized after Ginkgo builds the spec tree,
-			// it will be nil when the `Entry` function is called.
-			//
-			// This might also be some sort of golang quirk? But I highly doubt it.
+			// image is a pointer due to a workaround needed because of the way ginkgo works
+			// Ref: https://github.com/onsi/ginkgo/issues/378
 			func(image *string, expectedVerificationResult, expectErr bool, errorMessage string) {
 				verified, err := directVerifier.Verify(ctx, *image, kcr)
 				if expectErr {

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -57,9 +57,8 @@ var _ = Describe("Verifier", func() {
 		c := config.Config{
 			PublicKeys: []config.Key{
 				{
-					Name:      "test",
-					Key:       publicKey,
-					Algorithm: "",
+					Name: "test",
+					Key:  publicKey,
 				},
 			},
 		}

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -7,20 +7,18 @@ package verifysignature_test
 import (
 	"context"
 	"fmt"
-
 	"time"
 
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/config"
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/utils"
 	"github.com/gardener/gardener-extension-shoot-lakom-service/pkg/lakom/verifysignature"
-	"k8s.io/utils/ptr"
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-containerregistry/pkg/authn"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"k8s.io/utils/ptr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 )

--- a/pkg/lakom/verifysignature/verifier_test.go
+++ b/pkg/lakom/verifysignature/verifier_test.go
@@ -77,10 +77,6 @@ var _ = Describe("Verifier", func() {
 			directVerifier verifysignature.Verifier
 		)
 		BeforeEach(func() {
-			keys, err := utils.GetCosignPublicKeys([]byte(cosignPublicKey))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(keys).ToNot(BeZero())
-
 			// Interesting detail. Altough we've created the verifier to not allow insecure registries,
 			// (the `false` that is passed as a second argument), go-containerregistry still allows insecure
 			// connections if the registry is specifically `localhost`. Don't remember where the code for
@@ -133,12 +129,9 @@ var _ = Describe("Verifier", func() {
 		var (
 			cache          verifysignature.SignatureVerificationResultCache
 			cachedVerifier verifysignature.Verifier
+			err            error
 		)
 		BeforeEach(func() {
-			keys, err := utils.GetCosignPublicKeys([]byte(cosignPublicKey))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(keys).ToNot(BeZero())
-
 			cache, err = verifysignature.NewSignatureVerificationResultCache(refresh, ttl)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/lakom/verifysignature/verifysignature_suite_test.go
+++ b/pkg/lakom/verifysignature/verifysignature_suite_test.go
@@ -5,13 +5,187 @@
 package verifysignature_test
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
+	"os"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
+	registryv1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sigstore/cosign/v2/pkg/cosign"
+	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
+	ociRemote "github.com/sigstore/cosign/v2/pkg/oci/remote"
+	"github.com/sigstore/cosign/v2/pkg/oci/signed"
+	"github.com/sigstore/cosign/v2/pkg/oci/static"
+	"github.com/sigstore/sigstore/pkg/signature"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var (
+	scheme *runtime.Scheme
+
+	// Fake registry properties
+	registryURL *url.URL
+	server      *httptest.Server
+
+	signedImageTag    string
+	nonSignedImageTag string
+
+	// Key for signing images in fake registry
+	privateKey *ecdsa.PrivateKey
+
+	// Public key in PEM format for verifying signatures in the fake registry
+	publicKey string
 )
 
 func TestCMD(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "VerifySignature Suite")
+}
+
+var _ = BeforeSuite(func() {
+	scheme = runtime.NewScheme()
+	err := corev1.AddToScheme(scheme)
+	Expect(err).ToNot(HaveOccurred())
+
+	dirPath, err := os.MkdirTemp("", "verifysignature_test")
+	Expect(err).ToNot(HaveOccurred())
+	DeferCleanup(func() {
+		err := os.RemoveAll(dirPath)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	// Tests rely on a fake registry
+	registryURL, server = startFakeRegistry()
+	DeferCleanup(func() {
+		server.Close()
+	})
+
+	var signedImage registryv1.Image
+	signedImage, signedImageTag, err = writeRandomImage()
+	Expect(err).ToNot(HaveOccurred())
+	_, nonSignedImageTag, err = writeRandomImage()
+	Expect(err).ToNot(HaveOccurred())
+
+	privateKey, err = cosign.GeneratePrivateKey()
+	Expect(err).ToNot(HaveOccurred())
+	publicKey, err = publicKeyToPEM(privateKey.Public())
+	Expect(err).ToNot(HaveOccurred())
+
+	err = signImage(signedImage, signedImageTag)
+	Expect(err).ToNot(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	server.Close()
+})
+
+func startFakeRegistry() (*url.URL, *httptest.Server) {
+	nopLog := log.New(io.Discard, "", 0)
+	s := httptest.NewServer(registry.New(registry.Logger(nopLog)))
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		log.Fatal("Error parsing")
+	}
+
+	return u, s
+}
+
+func publicKeyToPEM(pub crypto.PublicKey) (string, error) {
+	// Marshal the public key to DER format
+	derBytes, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return "", err
+	}
+
+	// Create a PEM block
+	pemBlock := &pem.Block{
+		Type:  "PUBLIC KEY",
+		Bytes: derBytes,
+	}
+
+	// Encode the PEM block to a string
+	var pemBytes []byte
+	pemBytes = pem.EncodeToMemory(pemBlock)
+
+	return string(pemBytes), nil
+}
+
+func writeRandomImage() (registryv1.Image, string, error) {
+	// Create image
+	i, err := random.Image(512, 1)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Create tag
+	tagName := fmt.Sprintf("%s/%s:v0.1", registryURL.Host, "test")
+	tag, err := name.NewTag(tagName)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Write image to registry
+	err = remote.Write(tag, i)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// Get digest
+	headResponse, err := remote.Head(tag)
+
+	// TODO(rado): There should be an easier way than this
+	fullRef := tag.Context().Name() + "@" + headResponse.Digest.String()
+
+	return i, fullRef, nil
+}
+
+func signImage(image registryv1.Image, imageFullRef string) error {
+	digest, err := name.NewDigest(imageFullRef)
+	if err != nil {
+		return err
+	}
+
+	signerVerifier, err := signature.LoadSignerVerifier(privateKey, crypto.SHA256)
+	if err != nil {
+		return err
+	}
+
+	payload, signature, err := signature.SignImage(signerVerifier, digest, nil)
+	if err != nil {
+		return err
+	}
+
+	ociSignature, err := static.NewSignature(payload, base64.StdEncoding.EncodeToString(signature))
+	if err != nil {
+		return err
+	}
+
+	si := signed.Image(image)
+	si, err = mutate.AttachSignatureToImage(si, ociSignature)
+	if err != nil {
+		return err
+	}
+
+	err = ociRemote.WriteSignatures(digest.Context(), si)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/lakom/verifysignature/verifysignature_suite_test.go
+++ b/pkg/lakom/verifysignature/verifysignature_suite_test.go
@@ -7,6 +7,8 @@ package verifysignature_test
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
@@ -26,7 +28,6 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sigstore/cosign/v2/pkg/cosign"
 	"github.com/sigstore/cosign/v2/pkg/oci/mutate"
 	ociRemote "github.com/sigstore/cosign/v2/pkg/oci/remote"
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
@@ -97,7 +98,7 @@ var _ = BeforeSuite(func() {
 
 	nonExistentImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
 
-	privateKey, err := cosign.GeneratePrivateKey()
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	Expect(err).ToNot(HaveOccurred())
 	publicKey, err = publicKeyToPEM(privateKey.Public())
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/lakom/verifysignature/verifysignature_suite_test.go
+++ b/pkg/lakom/verifysignature/verifysignature_suite_test.go
@@ -102,17 +102,14 @@ var _ = BeforeSuite(func() {
 	publicKey, err = publicKeyToPEM(privateKey.Public())
 	Expect(err).ToNot(HaveOccurred())
 
-	err = signImage(signedImage, signedImageFullRef, privateKey)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(signImage(signedImage, signedImageFullRef, privateKey)).ToNot(HaveOccurred())
 })
 
 func startRegistry() (*url.URL, *httptest.Server) {
 	ginkgoLogger := log.New(GinkgoWriter, "", 0)
 	s := httptest.NewServer(registry.New(registry.Logger(ginkgoLogger)))
 	u, err := url.Parse(s.URL)
-	if err != nil {
-		log.Fatal("Error parsing")
-	}
+	Expect(err).ToNot(HaveOccurred())
 
 	return u, s
 }
@@ -151,8 +148,7 @@ func createTestImage(registryURL *url.URL, tag string) (registryv1.Image, name.R
 	}
 
 	// Write image to registry
-	err = remote.Write(tagRef, i)
-	if err != nil {
+	if err = remote.Write(tagRef, i); err != nil {
 		return nil, nil, err
 	}
 

--- a/pkg/lakom/verifysignature/verifysignature_suite_test.go
+++ b/pkg/lakom/verifysignature/verifysignature_suite_test.go
@@ -45,7 +45,7 @@ var (
 	// TagRef use the tag instead of the digest for referencing the artifact.
 	signedImageTagRef      string
 	unsignedImageTagRef    string
-	nonExistantImageTagRef string
+	nonExistentImageTagRef string
 
 	// Public key in PEM format for verifying signatures in the fake registry
 	publicKey string
@@ -95,7 +95,7 @@ var _ = BeforeSuite(func() {
 	signedImageTagRef = signedImageRef.Context().Tag(signedImageTag).String()
 	unsignedImageTagRef = unsignedImageRef.Context().Tag(unsignedImageTag).String()
 
-	nonExistantImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
+	nonExistentImageTagRef = fmt.Sprintf("%s:nonexistant", signedImageRef.Context().Name())
 
 	privateKey, err := cosign.GeneratePrivateKey()
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/lakom/verifysignature/verifysignature_suite_test.go
+++ b/pkg/lakom/verifysignature/verifysignature_suite_test.go
@@ -119,8 +119,7 @@ func publicKeyToPEM(pub crypto.PublicKey) (string, error) {
 	}
 
 	// Encode the PEM block to a string
-	var pemBytes []byte
-	pemBytes = pem.EncodeToMemory(pemBlock)
+	pemBytes := pem.EncodeToMemory(pemBlock)
 
 	return string(pemBytes), nil
 }
@@ -147,8 +146,10 @@ func writeRandomImage() (registryv1.Image, string, error) {
 
 	// Get digest
 	headResponse, err := remote.Head(tag)
+	if err != nil {
+		return nil, "", err
+	}
 
-	// TODO(rado): There should be an easier way than this
 	fullRef := tag.Context().Name() + "@" + headResponse.Digest.String()
 
 	return i, fullRef, nil

--- a/pkg/lakom/verifysignature/verifysignature_suite_test.go
+++ b/pkg/lakom/verifysignature/verifysignature_suite_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/sigstore/cosign/v2/pkg/oci/signed"
 	"github.com/sigstore/cosign/v2/pkg/oci/static"
 	"github.com/sigstore/sigstore/pkg/signature"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Faster, more stable tests. Easier to perform them, since we can now upload the objects we want to verify, rather than
relying on ones already existing in public registries.

Should potentially make the tests more robust.
**Which issue(s) this PR fixes**:
Fixes #128 
Fixes #37 

**Special notes for your reviewer**:
Setup code has been moved to a BeforeSuite ginkgo function that has been put in the `*_suite_test.go` files. 
There is most likely a way with which the code for creating and pushing the signature for an image can be improved, but I found the sigstore libraries very hard to work with and could not implement something simpler.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer

```
