### PR TITLE
Add support for projected kubeconfig in lakom chart

### DIFF
--- a/charts/gardener-extension-shoot-lakom-admission/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener-extension-shoot-lakom-admission/charts/runtime/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
       priorityClassName: {{ .Values.gardener.runtimeCluster.priorityClassName }}
       {{- end }}
       serviceAccountName: {{ include "name" . }}
-      {{- if .Values.kubeconfig }}
+      {{- if or .Values.kubeconfig .Values.projectedKubeconfig }}
       automountServiceAccountToken: false
       {{- end }}
       containers:
@@ -55,8 +55,7 @@ spec:
         - --webhook-config-namespace={{ .Release.Namespace }}
         {{- if .Values.kubeconfig }}
         - --kubeconfig=/etc/gardener-extension-shoot-lakom-admission/kubeconfig/kubeconfig
-        {{- end }}
-        {{- if .Values.projectedKubeconfig }}
+        {{- else if .Values.projectedKubeconfig }}
         - --kubeconfig={{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}/kubeconfig
         {{- end }}
         {{- if .Values.metricsPort }}
@@ -94,8 +93,7 @@ spec:
         - name: kubeconfig
           mountPath: /etc/gardener-extension-shoot-lakom-admission/kubeconfig
           readOnly: true
-        {{- end }}
-        {{- if .Values.projectedKubeconfig }}
+        {{- else if .Values.projectedKubeconfig }}
         - name: kubeconfig
           mountPath: {{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}
           readOnly: true
@@ -106,8 +104,7 @@ spec:
         secret:
           secretName: gardener-extension-shoot-lakom-admission-kubeconfig
           defaultMode: 420
-      {{- end }}
-      {{- if .Values.projectedKubeconfig }}
+      {{- else if .Values.projectedKubeconfig }}
       - name: kubeconfig
         projected:
           defaultMode: 420

--- a/charts/lakom/templates/deployment.yaml
+++ b/charts/lakom/templates/deployment.yaml
@@ -60,7 +60,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
       priorityClassName: {{ .Values.priorityClass.name }}
-      {{- if .Values.kubeconfig }}
+      {{- if or .Values.kubeconfig .Values.projectedKubeconfig }}
       automountServiceAccountToken: false
       {{- else }}
       serviceAccountName: {{ .Values.name }}
@@ -82,6 +82,8 @@ spec:
         - --port={{ .Values.serverPort }}
         {{- if .Values.kubeconfig }}
         - --kubeconfig=/etc/lakom/client/kubeconfig
+        {{- else if .Values.projectedKubeconfig }}
+        - --kubeconfig={{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}/kubeconfig
         {{- end }}
         - --use-only-image-pull-secrets={{ .Values.useOnlyImagePullSecrets }}
         - --insecure-allow-untrusted-images={{ .Values.allowUntrustedImages }}
@@ -113,6 +115,10 @@ spec:
         - name: kubeconfig
           mountPath: /etc/lakom/client
           readOnly: true
+        {{- else if .Values.projectedKubeconfig }}
+        - name: kubeconfig
+          mountPath: {{ required ".Values.projectedKubeconfig.baseMountPath is required" .Values.projectedKubeconfig.baseMountPath }}
+          readOnly: true
         {{- else }}
         - name: kube-api-access-lakom
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
@@ -129,6 +135,23 @@ spec:
       - name: kubeconfig
         secret:
           secretName: lakom-target-kubeconfig
+      {{- else if .Values.projectedKubeconfig }}
+      - name: kubeconfig
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: {{ required ".Values.projectedKubeconfig.genericKubeconfigSecretName is required" .Values.projectedKubeconfig.genericKubeconfigSecretName }}
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: {{ required ".Values.projectedKubeconfig.tokenSecretName is required" .Values.projectedKubeconfig.tokenSecretName }}
+              optional: false
       {{- else }}
       - name: kube-api-access-lakom
         projected:

--- a/charts/lakom/templates/validatingwebhookconfiguration.yaml
+++ b/charts/lakom/templates/validatingwebhookconfiguration.yaml
@@ -17,7 +17,7 @@ webhooks:
   clientConfig:
     caBundle: {{ .Values.admissionConfig.clientConfig.caBundle | b64enc }}
 {{- if .Values.admissionConfig.clientConfig.urlHostname }}
-    url: {{ printf "https://%s:443/lakom/resolve-tag-to-digest" (.Values.admissionConfig.clientConfig.urlHostname) }}
+    url: {{ printf "https://%s:443/lakom/verify-cosign-signature" (.Values.admissionConfig.clientConfig.urlHostname) }}
 {{- else }}
     service:
       name: {{ .Values.name }}

--- a/charts/lakom/values.yaml
+++ b/charts/lakom/values.yaml
@@ -37,6 +37,10 @@ useOnlyImagePullSecrets: false
 allowUntrustedImages: false
 allowInsecureRegistries: false
 kubeconfig: {}
+projectedKubeconfig: {}
+  # baseMountPath: /var/run/secrets/gardener.cloud
+  # genericKubeconfigSecretName: generic-token-kubeconfig
+  # tokenSecretName: access-shoot-lakom-admission
 admissionConfig:
   objectSelector: {}
   namespaceSelector:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support for projected kubeconfig in lakom chart.
The PR also contains a bugfix in the validating webhook configuration URL path and small improvements in the gardener-extension-shoot-lakom-admission chart to not use both kubeconfig and projectedKubeconfig

**Which issue(s) this PR fixes**:
Fixes #142 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feaeture operator
`lakom` helm chart now supports projected kubeconfig, this allows lakom to run in a source cluster and work for a target cluster, while the secrets with the kubeconfig and the token are externally managed.
```

```bugfix operator
Fix a bug when the `lakom` helm chart is installed with the value `.Values.admissionConfig.clientConfig.urlHostname` set the URL path in the ValidatingWebhookConfiguration was wrongly set to `/lakom/resolve-tag-to-digest` instead of `/lakom/verify-cosign-signature`.
```
