### PR TITLE
Fix lakom to consider algorithm when making trusted keys unique

### DIFF
--- a/pkg/lakom/config/config.go
+++ b/pkg/lakom/config/config.go
@@ -108,7 +108,10 @@ func uniqueKeys(keys []VerifierKey) []VerifierKey {
 		}
 
 		predicate := func(other VerifierKey) bool {
-			return key.Equal(other.Key)
+			return key.Equal(other.Key) &&
+				*item.Hash == *other.Hash &&
+				((item.RSAScheme == nil && other.RSAScheme == nil) ||
+					(item.RSAScheme != nil && other.RSAScheme != nil && *item.RSAScheme == *other.RSAScheme))
 		}
 		if !slices.ContainsFunc(result, predicate) {
 			result = append(result, item)

--- a/pkg/lakom/config/config_test.go
+++ b/pkg/lakom/config/config_test.go
@@ -11,31 +11,36 @@ import (
 )
 
 var _ = Describe("Complete Lakom Config", func() {
-
 	Context("Duplicate keys are removed", func() {
 		var (
-			rawKeys = []byte(`- name: test-01
+			config     *Config
+			parsedKeys []Key
+		)
+
+		BeforeEach(func() {
+			rawKeys := []byte(`- name: test-01-ecdsa-key
   algorithm: RSASSA-PKCS1-v1_5-SHA256
   key: |-
     -----BEGIN PUBLIC KEY-----
     MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE5WIqxApep8Q53M5zrd0Hhuk03tCn
     On/cxJW6vXn3mvlqgyc4MO/ZXb5EputelfyP5n1NYWWcomeQTDG/E3EbdQ==
     -----END PUBLIC KEY-----
-- name: test-02
-  algorithm: RSASSA-PKCS1-v1_5-SHA256
+- name: test-02-rsa-key
+  algorithm: RSASSA-PSS-SHA512
   key: |-
     -----BEGIN PUBLIC KEY-----
-    MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyLVOS/TWANf6sZJPDzogodvDz8NT
-    hjZVcW2ygAvImCAULGph2fqGkNUszl7ycJH/Dntw4wMLSbstUZomqPuIVQ==
+    MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAr/yPqOYHsJlqI1cj5TH+
+    BDeRrcwFFb1gHe3BMSrTeMSFEwNcJN6agdzN4OPBhbDkpsL/WRZjsQoVh3IcWgHy
+    rj8WgkukNuWrQIRzpY7NnDlVuL5IhrQxRxepDFOZB6AHr/QiE4xlKULa3820CQ2v
+    Fm3xiZEfElDrva0/0kbxVISMJ8VSeTmUf5XyYJ0PiKZ9/gyYTqi11NI2HTCYAb0h
+    5VX7TLEEGajRM6IYbfXt0Plw8ygYW5L1ze3DWUCd0qlIT27rrLeLIy1MNU1ExrJF
+    2IFIJ81kzOZRG107AXTP3Ms0+Agy+3/5joM/HmS0CH0HEHiFp+ZE856Sw5Mnlnac
+    JwIDAQAB
     -----END PUBLIC KEY-----
 `)
-			config     *Config
-			parsedKeys []Key
-		)
-		err := yaml.Unmarshal(rawKeys, &parsedKeys)
-		Expect(err).ToNot(HaveOccurred())
+			Expect(yaml.Unmarshal(rawKeys, &parsedKeys)).To(Succeed())
+			Expect(parsedKeys).To(HaveLen(2))
 
-		BeforeEach(func() {
 			config = &Config{}
 		})
 
@@ -65,6 +70,32 @@ var _ = Describe("Complete Lakom Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(len(completedConfig.Keys)).To(Equal(2))
+		})
+
+		It("should not remove keys if they are the same but have different hash function", func() {
+			config.PublicKeys = append(parsedKeys, parsedKeys[1])
+			Expect(config.PublicKeys).To(HaveLen(3))
+
+			config.PublicKeys[1].Algorithm = RSASSAPSSSHA512
+			config.PublicKeys[2].Algorithm = RSASSAPSSSHA384
+
+			completedConfig, err := config.Complete()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(completedConfig.Keys)).To(Equal(3))
+		})
+
+		It("should not remove keys if they are the same but have different RSA schemes", func() {
+			config.PublicKeys = append(parsedKeys, parsedKeys[1])
+			Expect(config.PublicKeys).To(HaveLen(3))
+
+			config.PublicKeys[1].Algorithm = RSAPKCS1v15SHA384
+			config.PublicKeys[2].Algorithm = RSASSAPSSSHA384
+
+			completedConfig, err := config.Complete()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(len(completedConfig.Keys)).To(Equal(3))
 		})
 
 		It("should have no effect if there are no keys in the config", func() {

--- a/pkg/lakom/verifysignature/admission.go
+++ b/pkg/lakom/verifysignature/admission.go
@@ -115,6 +115,10 @@ func (hb HandleBuilder) Build() (*handler, error) {
 		return nil, err
 	}
 
+	for _, key := range lakomConfig.Keys {
+		hb.logger.Info("Verifier is configured with a key", "name", key.Name, "type", fmt.Sprintf("%T", key.Key), "rsaScheme", key.RSAScheme, "hash", key.Hash)
+	}
+
 	verifier = NewDirectVerifier(*lakomConfig, hb.allowInsecureRegistries)
 	if hb.cacheTTL != 0 {
 		cache, err := NewSignatureVerificationResultCache(hb.cacheRefreshInterval, hb.cacheTTL)


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix lakom to consider algorithm when making trusted keys unique

**Which issue(s) this PR fixes**:
Fixes #

/kind bug

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Lakom admission controller is now considering two trusted keys different not only when the actual crypto keys are different but also when they are configured with different algorithms.
```
