### PR TITLE
Split scaffold helm deployment for admission in two

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -126,10 +126,17 @@ build:
 deploy:
   helm:
     releases:
-      - name: gardener-extension-shoot-lakom-admission
+      - name: gardener-extension-shoot-lakom-admission-runtime
         namespace: garden
         wait: true
-        chartPath: charts/gardener-extension-shoot-lakom-admission
+        chartPath: charts/gardener-extension-shoot-lakom-admission/charts/runtime
         setValueTemplates:
+          gardener.virtualCluster.enabled: "false"
           global.image.repository: '{{.IMAGE_REPO_local_skaffold_gardener_extension_shoot_lakom_admission}}'
           global.image.tag: '{{.IMAGE_TAG_local_skaffold_gardener_extension_shoot_lakom_admission}}@{{.IMAGE_DIGEST_local_skaffold_gardener_extension_shoot_lakom_admission}}'
+      - name: gardener-extension-shoot-lakom-admission-application
+        namespace: garden
+        wait: true
+        chartPath: charts/gardener-extension-shoot-lakom-admission/charts/application
+        setValueTemplates:
+          gardener.virtualCluster.enabled: "false"


### PR DESCRIPTION
**What this PR does / why we need it**:
After #133, the admission helm chart was split into two to accommodate deployment via `gardener-operator`.
We had forgotten to make the necessary changes to the skaffold config, breaking local deployment.
**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:
NONE
**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```

cc @georgibaltiev thank you for catching!
