### PR TITLE
Restrict Workflow permissions to read-only

### DIFF
--- a/.github/workflows/reuse-check.yaml
+++ b/.github/workflows/reuse-check.yaml
@@ -1,5 +1,8 @@
 name: REUSE Compliance Check
 
+permissions:
+  contents: read
+
 on: [push, pull_request]
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**:
Restrict Workflow permissions to read-only

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
