### PR TITLE
Enable dependabot to open PRs on gomod dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,3 +4,18 @@ updates:
   directory: /
   schedule:
     interval: daily
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 5
+  allow:
+  - dependency-name: "github.com/gardener/gardener"
+  - dependency-name: "github.com/gardener/service-account-issuer-discovery"
+  - dependency-name: "github.com/google/go-containerregistry"
+  - dependency-name: "github.com/google/go-containerregistry/pkg/authn/k8schain"
+  - dependency-name: "github.com/google/go-containerregistry/pkg/authn/kubernetes"
+  - dependency-name: "github.com/sigstore/cosign/v2"
+  - dependency-name: "github.com/sigstore/sigstore"
+  labels:
+  - kind/enhancement


### PR DESCRIPTION
**What this PR does / why we need it**:
Enable dependabot to open PRs on gomod dependencies

/kind enhancement
/area dev-productivity

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
