### PR TITLE
Fix Gardenlet tag resolver to not inject repository into the tag

### DIFF
--- a/pkg/lakom/resolvetag/resolver_test.go
+++ b/pkg/lakom/resolvetag/resolver_test.go
@@ -70,8 +70,8 @@ var _ = Describe("Resolver", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(resolvedImage).To(Equal(*expectedImage))
 			},
-			Entry("Resolve tag to digest", &signedImageTagRef, &signedImageFullRef, false, false, ""),
-			Entry("Do not run actual resolving of image with digest", &signedImageFullRef, &signedImageFullRef, true, false, ""),
+			Entry("Resolve tag to digest", &signedImageTagRef, &signedImageDigestRef, false, false, ""),
+			Entry("Do not run actual resolving of image with digest", &signedImageDigestRef, &signedImageDigestRef, true, false, ""),
 			Entry("Fail to parse bad image digest", ptr.To("gardener/non-existing-image@sha256:123"), ptr.To(""), true, false, "repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`"),
 			Entry("Fail to parse bad image tag", ptr.To("gardener/non-existing-image:123!"), ptr.To(""), true, false, "tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`"),
 			Entry("Fail to get non-existing image", &nonExistentImageTagRef, ptr.To(""), false, true, "unexpected status code 404 Not Found"),
@@ -102,8 +102,8 @@ var _ = Describe("Resolver", func() {
 				Expect(got).To(BeTrue())
 				Expect(cachedImage).To(Equal(*expectedImage))
 			},
-			Entry("Resolve tag to digest", &signedImageTagRef, &signedImageFullRef, false, false, ""),
-			Entry("Do not run actual resolving of image with digest", &signedImageFullRef, &signedImageFullRef, true, false, ""),
+			Entry("Resolve tag to digest", &signedImageTagRef, &signedImageDigestRef, false, false, ""),
+			Entry("Do not run actual resolving of image with digest", &signedImageDigestRef, &signedImageDigestRef, true, false, ""),
 			Entry("Fail to parse bad image digest", ptr.To("gardener/non-existing-image@sha256:123"), ptr.To(""), true, false, "repository can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-./`"),
 			Entry("Fail to parse bad image tag", ptr.To("gardener/non-existing-image:123!"), ptr.To(""), true, false, "tag can only contain the characters `abcdefghijklmnopqrstuvwxyz0123456789_-.ABCDEFGHIJKLMNOPQRSTUVWXYZ`"),
 			Entry("Fail to get non-existing image", &nonExistentImageTagRef, ptr.To(""), false, true, "unexpected status code 404 Not Found"),

--- a/pkg/lakom/resolvetag/resolvetag_suite_test.go
+++ b/pkg/lakom/resolvetag/resolvetag_suite_test.go
@@ -38,8 +38,8 @@ import (
 
 var (
 	// FullRef use the digest instead of the tag.
-	signedImageFullRef   string
-	unsignedImageFullRef string
+	signedImageDigestRef   string
+	unsignedImageDigestRef string
 
 	// TagRef use the tag instead of the digest for referencing the artifact.
 	signedImageTagRef      string
@@ -64,14 +64,12 @@ func TestCMD(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	scheme = runtime.NewScheme()
-	err := corev1.AddToScheme(scheme)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(corev1.AddToScheme(scheme)).To(Succeed())
 
 	dirPath, err := os.MkdirTemp("", "verifysignature_test")
 	Expect(err).ToNot(HaveOccurred())
 	DeferCleanup(func() {
-		err := os.RemoveAll(dirPath)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(os.RemoveAll(dirPath)).To(Succeed())
 	})
 
 	// Tests rely on a fake registry
@@ -85,8 +83,8 @@ var _ = BeforeSuite(func() {
 	_, unsignedImageRef, err := createTestImage(registryURL, unsignedImageTag)
 	Expect(err).ToNot(HaveOccurred())
 
-	signedImageFullRef = signedImageRef.Name()
-	unsignedImageFullRef = unsignedImageRef.Name()
+	signedImageDigestRef = signedImageRef.Name()
+	unsignedImageDigestRef = unsignedImageRef.Name()
 
 	signedImageTagRef = signedImageRef.Context().Tag(signedImageTag).String()
 	unsignedImageTagRef = unsignedImageRef.Context().Tag(unsignedImageTag).String()
@@ -96,7 +94,7 @@ var _ = BeforeSuite(func() {
 	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	Expect(err).ToNot(HaveOccurred())
 
-	Expect(signImage(signedImage, signedImageFullRef, privateKey)).ToNot(HaveOccurred())
+	Expect(signImage(signedImage, signedImageDigestRef, privateKey)).To(Succeed())
 })
 
 func startRegistry() (*url.URL, *httptest.Server) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix Gardenlet tag resolver to not inject repository into the tag

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the `Gardenlet` image tag resolver, where the resolved image is used as tag instead of just the digest, has been fixed. 
```

/kind bug