### PR TITLE
Fix API group of operator.gardener.cloud/v1alpha1.Extensions

### DIFF
--- a/docs/usage/lakom.md
+++ b/docs/usage/lakom.md
@@ -69,9 +69,9 @@ Here:
 
 By default, Lakom validates only `Pod` resources in the clusters that it covers.
 However, it also has the capabilities to validate the following Gardener specific resources:
-- `controllerdeployments.core.gardener.cloud/v1`
-- `gardenlets.seedmanagement.gardener.cloud/v1alpha1`
-- `extensions.operator.gardener.cloud/v1alpha1`
+- `core.gardener.cloud/v1.ControllerDeployments`
+- `seedmanagement.gardener.cloud/v1alpha1.Gardenlets`
+- `operator.gardener.cloud/v1alpha1.Extensions`
 
 > [!IMPORTANT]
 > When deploying Lakom via the helm chart in `/charts/lakom`, the `admissionConfig.rules` key

--- a/pkg/lakom/resolvetag/admission.go
+++ b/pkg/lakom/resolvetag/admission.go
@@ -122,7 +122,7 @@ var (
 	podGVK                  = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
 	controllerDeploymentGVK = metav1.GroupVersionKind{Group: "core.gardener.cloud", Kind: "ControllerDeployment", Version: "v1"}
 	gardenletGVK            = metav1.GroupVersionKind{Group: "seedmanagement.gardener.cloud", Kind: "Gardenlet", Version: "v1alpha1"}
-	extensionGVK            = metav1.GroupVersionKind{Group: "extensions.operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
+	extensionGVK            = metav1.GroupVersionKind{Group: "operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
 	allowedResources        = sets.New(podGVK, controllerDeploymentGVK, gardenletGVK, extensionGVK)
 	controlledOperations    = sets.NewString(string(admissionv1.Create), string(admissionv1.Update))
 )
@@ -135,7 +135,7 @@ func (h *handler) GetLogger() logr.Logger {
 // - v1/Pod
 // - core.gardener.cloud/v1/ControllerDeployment
 // - seedmanagement.gardener.cloud/v1alpha1/Gardenlet
-// - extensions.operator.gardener.cloud/v1alpha1/Extension
+// - operator.gardener.cloud/v1alpha1/Extension
 func (h *handler) Handle(ctx context.Context, request admission.Request) admission.Response {
 	var (
 		patch []byte

--- a/pkg/lakom/resolvetag/admission_test.go
+++ b/pkg/lakom/resolvetag/admission_test.go
@@ -36,7 +36,7 @@ var (
 	podGVK                  = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
 	controllerDeploymentGVK = metav1.GroupVersionKind{Group: "core.gardener.cloud", Kind: "ControllerDeployment", Version: "v1"}
 	gardenletGVK            = metav1.GroupVersionKind{Group: "seedmanagement.gardener.cloud", Kind: "Gardenlet", Version: "v1alpha1"}
-	extensionGVK            = metav1.GroupVersionKind{Group: "extensions.operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
+	extensionGVK            = metav1.GroupVersionKind{Group: "operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
 )
 
 var _ = Describe("Admission Handler", func() {

--- a/pkg/lakom/verifysignature/admission.go
+++ b/pkg/lakom/verifysignature/admission.go
@@ -147,7 +147,7 @@ var (
 	podGVK                  = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
 	controllerDeploymentGVK = metav1.GroupVersionKind{Group: "core.gardener.cloud", Kind: "ControllerDeployment", Version: "v1"}
 	gardenletGVK            = metav1.GroupVersionKind{Group: "seedmanagement.gardener.cloud", Kind: "Gardenlet", Version: "v1alpha1"}
-	extensionGVK            = metav1.GroupVersionKind{Group: "extensions.operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
+	extensionGVK            = metav1.GroupVersionKind{Group: "operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
 	allowedResources        = sets.New(podGVK, controllerDeploymentGVK, gardenletGVK, extensionGVK)
 	controlledOperations    = sets.NewString(string(admissionv1.Create), string(admissionv1.Update))
 )
@@ -165,9 +165,9 @@ type verificationTarget struct {
 
 // Handle handles admission requests. It works only on create/update on one of:
 // - v1.Pod
-// - core.gardener.cloud/ControllerDeployment/v1
-// - seedmanagement.gardener.cloud/Gardenlet/v1alpha1
-// - extensions.operator.gardener.cloud/Extension/v1alpha1
+// - core.gardener.cloud/v1.ControllerDeployment
+// - seedmanagement.gardener.cloud/v1alpha1.Gardenlet
+// - operator.gardener.cloud/v1alpha1.Extension
 // and ignores anything else. Ensures that each resource is using images or
 // helm charts signed by at least one of the provided public cosign keys.
 //
@@ -338,9 +338,9 @@ func (h *handler) extractGardenletVerificationTargets(ctx context.Context, garde
 
 // extractExtensionVerificationTargets returns an array of verification targets from the extension.
 // The verification targets are extracted from the following fields:
-// - extensions.operator.gardener.cloud/Extension: spec.deployment.admission.runtimeCluster.helm.ociRepository
-// - extensions.operator.gardener.cloud/Extension: spec.deployment.admission.virtualCluster.helm.ociRepository
-// - extensions.operator.gardener.cloud/Extension: spec.deployment.extension.helm.ociRepository
+// - operator.gardener.cloud/v1alpha1.Extension: spec.deployment.admission.runtimeCluster.helm.ociRepository
+// - operator.gardener.cloud/v1alpha1.Extension: spec.deployment.admission.virtualCluster.helm.ociRepository
+// - operator.gardener.cloud/v1alpha1.Extension: spec.deployment.extension.helm.ociRepository
 func (h *handler) extractExtensionVerificationTargets(ctx context.Context, extension operatorv1alpha1.Extension) ([]verificationTarget, utils.KeyChainReader, error) {
 	var (
 		verificationTargets []verificationTarget

--- a/pkg/lakom/verifysignature/admission_test.go
+++ b/pkg/lakom/verifysignature/admission_test.go
@@ -35,7 +35,7 @@ var (
 	podGVK                  = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
 	controllerDeploymentGVK = metav1.GroupVersionKind{Group: "core.gardener.cloud", Kind: "ControllerDeployment", Version: "v1"}
 	gardenletGVK            = metav1.GroupVersionKind{Group: "seedmanagement.gardener.cloud", Kind: "Gardenlet", Version: "v1alpha1"}
-	extensionGVK            = metav1.GroupVersionKind{Group: "extensions.operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
+	extensionGVK            = metav1.GroupVersionKind{Group: "operator.gardener.cloud", Kind: "Extension", Version: "v1alpha1"}
 )
 
 var _ = Describe("Admission Handler", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix API group of operator.gardener.cloud/v1alpha1.Extensions

/kind bug

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the lakom admission controller set to admit requests on `extensions.operator.gardener.cloud/v1alpha1.Extensions` instead of `operator.gardener.cloud/v1alpha1.Extensions` has been fixed.
```
