### PR TITLE
New local registry domain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ update-skaffold-deps: $(YQ)
 
 # speed-up skaffold deployments by building all images concurrently
 export SKAFFOLD_BUILD_CONCURRENCY = 0
-extension-up extension-dev extension-operator-up: export SKAFFOLD_DEFAULT_REPO = garden.local.gardener.cloud:5001
+extension-up extension-dev extension-operator-up: export SKAFFOLD_DEFAULT_REPO = registry.local.gardener.cloud:5001
 extension-up extension-dev extension-operator-up: export SKAFFOLD_PUSH = true
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 extension-up extension-dev extension-down extension-operator-up extension-operator-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=extension-local

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The `Lakom` admission controller can be configured with `make dev-setup` and sta
 You can run the lakom extension controller locally on your machine by executing `make start`.
 
 If you'd like to develop Lakom using a local cluster such as KinD, make sure your `KUBECONFIG` environment variable is targeting the local Garden cluster.
-Add `127.0.0.1 garden.local.gardener.cloud` to your `/etc/hosts`. You can then run:
+Add `127.0.0.1 registry.local.gardener.cloud` to your `/etc/hosts`. You can then run:
 
 ```bash
 make extension-up

--- a/skaffold-operator.yaml
+++ b/skaffold-operator.yaml
@@ -17,7 +17,7 @@ build:
         - name: sha
           inputDigest: {}
   insecureRegistries:
-    - garden.local.gardener.cloud:5001
+    - registry.local.gardener.cloud:5001
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-lakom-service
       requires:

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -10,7 +10,7 @@ build:
   tagPolicy:
     inputDigest: {}
   insecureRegistries:
-    - garden.local.gardener.cloud
+    - registry.local.gardener.cloud
   artifacts:
     - image: local-skaffold/gardener-extension-shoot-lakom-service
       # The shoot-lakom-service controller uses imageVectorOverwrite to configure


### PR DESCRIPTION
**What this PR does / why we need it**:
With https://github.com/gardener/gardener/pull/13551 the local registry domain has been changed from `garden.local.gardener.cloud` to `registry.local.gardener.cloud`.
**Which issue(s) this PR fixes**:
NONE

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Updated local setup to use new registry domain `registry.local.gardener.cloud`.
```
