### PR TITLE
Let Dependabot set kind/enhancement label on opened PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,6 +4,8 @@ updates:
   directory: /
   schedule:
     interval: daily
+  labels:
+  - kind/enhancement
 - package-ecosystem: gomod
   directory: /
   schedule:


### PR DESCRIPTION
/kind enhancement
/area dev-productivity

What this PR does / why we need it:
Let Dependabot set kind/enhancement label on opened PRs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
