### PR TITLE
GHA: Update setup-go action to v6 and go-version to 1.26

### DIFF
--- a/.github/actions/prepare-release/action.yaml
+++ b/.github/actions/prepare-release/action.yaml
@@ -3,9 +3,9 @@ name: Prepare Release
 runs:
   using: composite
   steps:
-    - uses: actions/setup-go@v5
+    - uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
     - name: make-generate
       shell: bash
       run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -132,9 +132,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - uses: actions/checkout@v4
       - uses: gardener/cc-utils/.github/actions/setup-git-identity@master
       - name: run-verify


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
GHA: Update setup-go action to v6 and go-version to 1.26

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```