### PR TITLE
Fix go-yaml version hint via component descriptor

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -11,5 +11,5 @@ main-source:
           we use gosec for sast scanning. See attached log.
     - name: cloud.gardener.cnudie/dso/scanning-hints/package-versions
       value:
-        - name: go-yaml # Explicitly set the version of go.yaml.in/yaml/v2 for scanning tools that cannot detect it properly.
-          version: v2.4.3
+        - name: go-yaml # Explicitly set the version of gopkg.in/yaml.v2 for scanning tools that cannot detect it properly.
+          version: v2.4.0


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind task

**What this PR does / why we need it**:
Fix go-yaml version hint via component descriptor.
The affected module is `gopkg.in/yaml.v2` not `go.yaml.in/yaml/v2`

**Which issue(s) this PR fixes**:
Follow-up on #275

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```