### PR TITLE
Switch the default scope to `KubeSystem`

### DIFF
--- a/docs/usage/shoot-extension.md
+++ b/docs/usage/shoot-extension.md
@@ -34,8 +34,8 @@ The `scope` field instruct lakom which pods to consider for validation.
 
 |Scope|Description|
 |-----|-----------|
-|`KubeSystem`|Lakom will validate all pods in the `kube-system` namespace.|
-|`KubeSystemManagedByGardener`(default)|Lakom will validate all pods in the `kube-system` namespace that are labeled with `resources.gardener.cloud/managed-by=gardener`.|
+|`KubeSystem`(default)|Lakom will validate all pods in the `kube-system` namespace.|
+|`KubeSystemManagedByGardener`|Lakom will validate all pods in the `kube-system` namespace that are labeled with `resources.gardener.cloud/managed-by=gardener`.|
 |`Cluster`|Lakom will validate all pods in all namespaces.|
 
 ### TrustedKeysResourceName

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -111,12 +111,12 @@ func (a *actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 	if ex.Spec.ProviderConfig != nil {
 		if _, _, err := a.decoder.Decode(ex.Spec.ProviderConfig.Raw, nil, lakomProviderConfig); err != nil {
 			// Apply default values if provider config has not been provided
-			logger.Error(err, "Could not decode provider config. Using default value `KubeSystemManagedByGardener` for scope")
+			logger.Error(err, "Could not decode provider config. Using default value `KubeSystem` for scope")
 		}
 	}
 	if lakomProviderConfig.Scope == nil {
-		logger.Info("No scope specified. Using default value `KubeSystemManagedByGardener` for scope")
-		lakomProviderConfig.Scope = ptr.To(lakom.KubeSystemManagedByGardener)
+		logger.Info("No scope specified. Using default value `KubeSystem` for scope")
+		lakomProviderConfig.Scope = ptr.To(lakom.KubeSystem)
 	}
 
 	// initialize SecretsManager based on Cluster object

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Actuator", func() {
 		const (
 			shootNamespace                  = "garden-foo"
 			extensionNamespace              = "shoot--foo--bar"
-			scope                           = lakom.KubeSystemManagedByGardener
+			scope                           = lakom.KubeSystem
 			shootAccessServiceAccountName   = "extension-shoot-lakom-service-access"
 			managedByGardenerObjectSelector = `
     matchExpressions:
@@ -87,8 +87,8 @@ var _ = Describe("Actuator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(manifests).To(ConsistOf(
-				expectedSeedValidatingWebhook(caBundle, extensionNamespace, managedByGardenerObjectSelector, kubeSystemNamespaceSelector),
-				expectedShootMutatingWebhook(caBundle, extensionNamespace, managedByGardenerObjectSelector, kubeSystemNamespaceSelector),
+				expectedSeedValidatingWebhook(caBundle, extensionNamespace, emptyObjectSelector, kubeSystemNamespaceSelector),
+				expectedShootMutatingWebhook(caBundle, extensionNamespace, emptyObjectSelector, kubeSystemNamespaceSelector),
 				expectedShootClusterRole(),
 				expectedShootRoleBinding(shootAccessServiceAccountName, scope),
 			))
@@ -101,7 +101,7 @@ var _ = Describe("Actuator", func() {
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(manifests).To(ContainElement(expectedShootMutatingWebhook(ca, ns, managedByGardenerObjectSelector, kubeSystemNamespaceSelector)))
+				Expect(manifests).To(ContainElement(expectedShootMutatingWebhook(ca, ns, emptyObjectSelector, kubeSystemNamespaceSelector)))
 			},
 			Entry("Global CA bundle and namespace name", caBundle, extensionNamespace),
 			Entry("Custom CA bundle and namespace name", []byte("anotherCABundle"), "different-namespace"),
@@ -114,7 +114,7 @@ var _ = Describe("Actuator", func() {
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(manifests).To(ContainElement(expectedSeedValidatingWebhook(ca, ns, managedByGardenerObjectSelector, kubeSystemNamespaceSelector)))
+				Expect(manifests).To(ContainElement(expectedSeedValidatingWebhook(ca, ns, emptyObjectSelector, kubeSystemNamespaceSelector)))
 			},
 			Entry("Global CA bundle and namespace name", caBundle, extensionNamespace),
 			Entry("Custom CA bundle and namespace name", []byte("anotherCABundle"), "different-namespace"),


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area security
  /area documentation
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area compliance
/kind api-change

**What this PR does / why we need it**:
PR switches the default scope to 'KubeSystem', which, by default, forces all images in the `kube-system` to be validated, which increases confidence in the "system" workloads.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The default scope for `lakom` is changed to 'KubeSystem'
```