### PR TITLE
Fix `KubeSystem*` scopes to verify also the pods in the `kubernetes-dashboard` namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ export SHOOT_ADMISSION_LD_FLAGS := -w $(shell bash $(GARDENER_HACK_DIR)/get-buil
 .PHONY: start
 start:
 	@LEADER_ELECTION_NAMESPACE=$(LEADER_ELECTION_NAMESPACE) go run \
-		-ldflags $(EXTENSION_LD_FLAGS) \
+		-ldflags "$(EXTENSION_LD_FLAGS)" \
 		./cmd/$(EXTENSION_FULL_NAME) \
 		--ignore-operation-annotation=$(IGNORE_OPERATION_ANNOTATION) \
 		--leader-election=$(LEADER_ELECTION) \
@@ -50,7 +50,7 @@ start:
 .PHONY: start-lakom
 start-lakom:
 	@go run \
-		-ldflags $(ADMISSION_LD_FLAGS) \
+		-ldflags "$(ADMISSION_LD_FLAGS)" \
 		./cmd/$(ADMISSION_NAME) \
 		--kubeconfig=$(KUBECONFIG) \
 		--tls-cert-dir=example/lakom/tls/ \

--- a/docs/usage/shoot-extension.md
+++ b/docs/usage/shoot-extension.md
@@ -34,8 +34,8 @@ The `scope` field instruct lakom which pods to consider for validation.
 
 | Scope | Description |
 | ----- | ----------- |
-| `KubeSystem` | Lakom will validate all pods in the `kube-system` namespace. |
-| `KubeSystemManagedByGardener`(default) | Lakom will validate all pods in the `kube-system` namespace that are labeled with `resources.gardener.cloud/managed-by=gardener`. |
+| `KubeSystem` | Lakom will validate all pods in the `kube-system` namespace. When the Gardener `KubernetesDashboard` addon is enabled, the pods in the `kubernetes-dashboard` namespace are also validated. |
+| `KubeSystemManagedByGardener`(default) | Lakom will validate all pods in the `kube-system` namespace that are labeled with `resources.gardener.cloud/managed-by=gardener`. When the Gardener `KubernetesDashboard` addon is enabled, the pods with same label in the`kubernetes-dashboard` namespace are also validated. |
 | `Cluster` | Lakom will validate all pods in all namespaces. |
 
 > [!NOTE]

--- a/docs/usage/shoot-extension.md
+++ b/docs/usage/shoot-extension.md
@@ -35,7 +35,7 @@ The `scope` field instruct lakom which pods to consider for validation.
 | Scope | Description |
 | ----- | ----------- |
 | `KubeSystem` | Lakom will validate all pods in the `kube-system` namespace. When the Gardener `KubernetesDashboard` addon is enabled, the pods in the `kubernetes-dashboard` namespace are also validated. |
-| `KubeSystemManagedByGardener`(default) | Lakom will validate all pods in the `kube-system` namespace that are labeled with `resources.gardener.cloud/managed-by=gardener`. When the Gardener `KubernetesDashboard` addon is enabled, the pods with same label in the`kubernetes-dashboard` namespace are also validated. |
+| `KubeSystemManagedByGardener`(default) | Lakom will validate all pods in the `kube-system` namespace that are labeled with `resources.gardener.cloud/managed-by=gardener`. When the Gardener `KubernetesDashboard` addon is enabled, the pods with same label in the `kubernetes-dashboard` namespace are also validated. |
 | `Cluster` | Lakom will validate all pods in all namespaces. |
 
 > [!NOTE]

--- a/pkg/apis/lakom/types.go
+++ b/pkg/apis/lakom/types.go
@@ -15,11 +15,15 @@ import (
 type ScopeType string
 
 const (
-	// KubeSystem denotes the `kube-system` namespace
+	// KubeSystem scope is used to restrict the scope of lakom admission to all pods in the `kube-system` namespaces.
+	// When the Gardener `KubernetesDashboard` addon is enabled, the pods in the `kubernetes-dashboard` namespace are also validated.
 	KubeSystem ScopeType = "KubeSystem"
-	// KubeSystemManagedByGardener denotes pods in the `kube-system` namespace that have a `resources.gardener.cloud/managed-by=gardener` label
+	// KubeSystemManagedByGardener scope is used to restrict the scope of lakom admission to the pods in the `kube-system`
+	// namespaces that are labeled with `resources.gardener.cloud/managed-by=gardener`.
+	// When the Gardener `KubernetesDashboard` addon is enabled, the pods with the same label
+	// in the `kubernetes-dashboard` namespace are also validated.
 	KubeSystemManagedByGardener ScopeType = "KubeSystemManagedByGardener"
-	// Cluster denotes the whole cluster
+	// Cluster scope configured lakom admission for all pods in all namespaces.
 	Cluster ScopeType = "Cluster"
 )
 

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -613,44 +613,34 @@ func getSeedResources(
 }
 
 func scopeToObjectSelector(scope lakom.ScopeType) metav1.LabelSelector {
-	var objectSelector = metav1.LabelSelector{}
-	switch scope {
-	case lakom.KubeSystemManagedByGardener:
-		objectSelector = metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{
-				{
-					Key:      resourcesv1alpha1.ManagedBy,
-					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{"gardener"},
-				},
+	if scope == lakom.KubeSystemManagedByGardener {
+		return metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      resourcesv1alpha1.ManagedBy,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"gardener"},
 			},
-		}
-	case lakom.KubeSystem:
-	case lakom.Cluster:
+		}}
 	}
 
-	return objectSelector
+	return metav1.LabelSelector{}
 }
 
 func scopeToNamespaceSelector(scope lakom.ScopeType) metav1.LabelSelector {
-	namespaceSelector := metav1.LabelSelector{
-		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{
-				Key:      corev1.LabelMetadataName,
-				Operator: metav1.LabelSelectorOpIn,
-				Values:   []string{metav1.NamespaceSystem},
+	if scope == lakom.Cluster {
+		return metav1.LabelSelector{}
+	}
+
+	return metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+		{
+			Key:      corev1.LabelMetadataName,
+			Operator: metav1.LabelSelectorOpIn,
+			Values: []string{
+				metav1.NamespaceSystem,
+				"kubernetes-dashboard", // TODO(vpnachev): Remove after support for shoots using kubernetes version <v1.35.0 is dropped, i.e. the support for the kubernetes dashboard addon is removed.
 			},
 		},
-	}
-
-	switch scope {
-	case lakom.KubeSystemManagedByGardener:
-	case lakom.KubeSystem:
-	case lakom.Cluster:
-		namespaceSelector = metav1.LabelSelector{}
-	}
-
-	return namespaceSelector
+	}}
 }
 
 func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessServiceAccountName string, scope lakom.ScopeType) (map[string][]byte, error) {

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -61,6 +61,8 @@ import (
 const (
 	// ActuatorName is the name of the Lakom Service actuator.
 	ActuatorName = constants.ExtensionType + "-actuator"
+
+	kubernetesDashboardNamespaceName = "kubernetes-dashboard"
 )
 
 // NewActuator returns an actuator responsible for Extension resources.
@@ -198,6 +200,7 @@ func (a *actuator) Reconcile(ctx context.Context, logger logr.Logger, ex *extens
 		namespace,
 		lakomShootAccessSecret.ServiceAccountName,
 		*lakomProviderConfig.Scope,
+		v1beta1helper.KubernetesDashboardEnabled(cluster.Shoot.Spec.Addons), //nolint:staticcheck
 	)
 
 	if err != nil {
@@ -626,24 +629,28 @@ func scopeToObjectSelector(scope lakom.ScopeType) metav1.LabelSelector {
 	return metav1.LabelSelector{}
 }
 
-func scopeToNamespaceSelector(scope lakom.ScopeType) metav1.LabelSelector {
+func scopeToNamespaceSelector(scope lakom.ScopeType, dashboardEnabled bool) metav1.LabelSelector {
 	if scope == lakom.Cluster {
 		return metav1.LabelSelector{}
+	}
+
+	namespaces := []string{metav1.NamespaceSystem}
+	if dashboardEnabled {
+		// TODO(vpnachev): Remove after support for shoots using kubernetes version <v1.35.0 is dropped,
+		// i.e. the support for the kubernetes dashboard addon is removed.
+		namespaces = append(namespaces, kubernetesDashboardNamespaceName)
 	}
 
 	return metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
 		{
 			Key:      corev1.LabelMetadataName,
 			Operator: metav1.LabelSelectorOpIn,
-			Values: []string{
-				metav1.NamespaceSystem,
-				"kubernetes-dashboard", // TODO(vpnachev): Remove after support for shoots using kubernetes version <v1.35.0 is dropped, i.e. the support for the kubernetes dashboard addon is removed.
-			},
+			Values:   namespaces,
 		},
 	}}
 }
 
-func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessServiceAccountName string, scope lakom.ScopeType) (map[string][]byte, error) {
+func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessServiceAccountName string, scope lakom.ScopeType, dashboardEnabled bool) (map[string][]byte, error) {
 	var (
 		matchPolicy          = admissionregistrationv1.Equivalent
 		sideEffectClass      = admissionregistrationv1.SideEffectClassNone
@@ -652,7 +659,7 @@ func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessSe
 		webhookHost          = fmt.Sprintf("https://%s.%s", constants.ExtensionServiceName, extensionNamespace)
 		validatingWebhookURL = webhookHost + constants.LakomVerifyCosignSignaturePath
 		mutatingWebhookURL   = webhookHost + constants.LakomResolveTagPath
-		namespaceSelector    = scopeToNamespaceSelector(scope)
+		namespaceSelector    = scopeToNamespaceSelector(scope, dashboardEnabled)
 		objectSelector       = scopeToObjectSelector(scope)
 		rules                = []admissionregistrationv1.RuleWithOperations{{
 			Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create, admissionregistrationv1.Update},
@@ -665,7 +672,8 @@ func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessSe
 	)
 
 	shootRegistry := managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-	shootResources, err := shootRegistry.AddAllAndSerialize(
+	shootResources, err := shootRegistry.AddAllAndSerialize(append(
+		getRoleBindings(scope, shootAccessServiceAccountName, dashboardEnabled),
 		&admissionregistrationv1.MutatingWebhookConfiguration{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:   constants.WebhookConfigurationName,
@@ -721,8 +729,7 @@ func getShootResources(webhookCaBundle []byte, extensionNamespace, shootAccessSe
 				},
 			},
 		},
-		getRoleBinding(scope, shootAccessServiceAccountName),
-	)
+	)...)
 
 	if err != nil {
 		return nil, err
@@ -759,7 +766,7 @@ func getClientKeys(ctx context.Context, client client.Client, resources []garden
 	return clientKeys, nil
 }
 
-func getRoleBinding(scope lakom.ScopeType, shootAccessServiceAccountName string) client.Object {
+func getRoleBindings(scope lakom.ScopeType, shootAccessServiceAccountName string, dashboardEnabled bool) []client.Object {
 	roleRef := rbacv1.RoleRef{
 		APIGroup: "rbac.authorization.k8s.io",
 		Kind:     "ClusterRole",
@@ -777,7 +784,7 @@ func getRoleBinding(scope lakom.ScopeType, shootAccessServiceAccountName string)
 	}
 
 	if scope == lakom.Cluster {
-		return &rbacv1.ClusterRoleBinding{
+		return []client.Object{&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        constants.LakomResourceReader,
 				Labels:      getLabels(),
@@ -785,10 +792,10 @@ func getRoleBinding(scope lakom.ScopeType, shootAccessServiceAccountName string)
 			},
 			RoleRef:  roleRef,
 			Subjects: subjects,
-		}
+		}}
 	}
 
-	return &rbacv1.RoleBinding{
+	roleBindings := []client.Object{&rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        constants.LakomResourceReader,
 			Namespace:   metav1.NamespaceSystem,
@@ -797,5 +804,20 @@ func getRoleBinding(scope lakom.ScopeType, shootAccessServiceAccountName string)
 		},
 		RoleRef:  roleRef,
 		Subjects: subjects,
+	}}
+
+	if dashboardEnabled {
+		roleBindings = append(roleBindings, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        constants.LakomResourceReader,
+				Namespace:   kubernetesDashboardNamespaceName,
+				Labels:      getLabels(),
+				Annotations: annotations,
+			},
+			RoleRef:  roleRef,
+			Subjects: subjects,
+		})
 	}
+
+	return roleBindings
 }

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -81,7 +81,8 @@ var _ = Describe("Actuator", func() {
     - key: kubernetes.io/metadata.name
       operator: In
       values:
-      - kube-system`
+      - kube-system
+      - kubernetes-dashboard`
 			emptyNamespaceSelector = ` {}`
 		)
 		var (

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Actuator", func() {
 		}
 	},
 		Entry("One ClusterRoleBinding only when scope is Cluster (dashboard disabled)", lakom.Cluster, false, true, 1),
-		Entry("One ClusterRoleBinding only when scope is Cluster (dashboard enabled)", lakom.Cluster, false, true, 1),
+		Entry("One ClusterRoleBinding only when scope is Cluster (dashboard enabled)", lakom.Cluster, true, true, 1),
 		Entry("One RoleBinding when scope is KubeSystem (dashboard disabled)", lakom.KubeSystem, false, false, 1),
 		Entry("Two RoleBindings when scope is KubeSystem (dashboard enabled)", lakom.KubeSystem, true, false, 2),
 		Entry("One RoleBinding when scope is KubeSystemManagedByGardener (dashboard disabled)", lakom.KubeSystemManagedByGardener, false, false, 1),

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -63,11 +64,35 @@ var _ = Describe("Actuator", func() {
 		Entry("Overwrite scope: KubeSystemManagedByGardener", lakom.KubeSystemManagedByGardener, "KubeSystemManagedByGardener"),
 	)
 
+	DescribeTable("Should get correct (cluster)rolebindings", func(scope lakom.ScopeType, dashboardEnabled bool, expectCRB bool, expectedBindingsCount int) {
+		bindings := getRoleBindings(scope, "sa-name", dashboardEnabled)
+		Expect(bindings).To(HaveLen(expectedBindingsCount))
+		if expectCRB {
+			Expect(bindings[0]).To(BeAssignableToTypeOf(&rbacv1.ClusterRoleBinding{}))
+		} else {
+			Expect(bindings[0]).To(BeAssignableToTypeOf(&rbacv1.RoleBinding{}))
+			Expect(bindings[0].GetNamespace()).To(Equal("kube-system"))
+
+			if expectedBindingsCount == 2 {
+				Expect(bindings[1]).To(BeAssignableToTypeOf(&rbacv1.RoleBinding{}))
+				Expect(bindings[1].GetNamespace()).To(Equal("kubernetes-dashboard"))
+			}
+		}
+	},
+		Entry("One ClusterRoleBinding only when scope is Cluster (dashboard disabled)", lakom.Cluster, false, true, 1),
+		Entry("One ClusterRoleBinding only when scope is Cluster (dashboard enabled)", lakom.Cluster, false, true, 1),
+		Entry("One RoleBinding when scope is KubeSystem (dashboard disabled)", lakom.KubeSystem, false, false, 1),
+		Entry("Two RoleBindings when scope is KubeSystem (dashboard enabled)", lakom.KubeSystem, true, false, 2),
+		Entry("One RoleBinding when scope is KubeSystemManagedByGardener (dashboard disabled)", lakom.KubeSystemManagedByGardener, false, false, 1),
+		Entry("Two RoleBindings when scope is KubeSystemManagedByGardener (dashboard enabled)", lakom.KubeSystemManagedByGardener, true, false, 2),
+	)
+
 	Context("getShootResources", func() {
 		const (
 			shootNamespace                  = "garden-foo"
 			extensionNamespace              = "shoot--foo--bar"
 			scope                           = lakom.KubeSystemManagedByGardener
+			dashboardEnabled                = false
 			shootAccessServiceAccountName   = "extension-shoot-lakom-service-access"
 			managedByGardenerObjectSelector = `
     matchExpressions:
@@ -77,6 +102,12 @@ var _ = Describe("Actuator", func() {
       - gardener`
 			emptyObjectSelector         = ` {}`
 			kubeSystemNamespaceSelector = `
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+      - kube-system`
+			kubeSystemAndDashboardNamespaceSelector = `
     matchExpressions:
     - key: kubernetes.io/metadata.name
       operator: In
@@ -91,7 +122,7 @@ var _ = Describe("Actuator", func() {
 
 		It("Should ensure the correct shoot resources are created", func() {
 
-			resources, err := getShootResources(caBundle, extensionNamespace, shootAccessServiceAccountName, scope)
+			resources, err := getShootResources(caBundle, extensionNamespace, shootAccessServiceAccountName, scope, false)
 			Expect(err).ToNot(HaveOccurred())
 			manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 			Expect(err).ToNot(HaveOccurred())
@@ -100,13 +131,27 @@ var _ = Describe("Actuator", func() {
 				expectedSeedValidatingWebhook(caBundle, extensionNamespace, managedByGardenerObjectSelector, kubeSystemNamespaceSelector),
 				expectedShootMutatingWebhook(caBundle, extensionNamespace, managedByGardenerObjectSelector, kubeSystemNamespaceSelector),
 				expectedShootClusterRole(),
-				expectedShootRoleBinding(shootAccessServiceAccountName, scope),
+				expectedShootRoleBinding(shootAccessServiceAccountName, scope, "kube-system"),
+			))
+
+			By("Enable kubernetes dashboard addon")
+			resources, err = getShootResources(caBundle, extensionNamespace, shootAccessServiceAccountName, scope, true)
+			Expect(err).ToNot(HaveOccurred())
+			manifests, err = test.ExtractManifestsFromManagedResourceData(resources)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(manifests).To(ConsistOf(
+				expectedSeedValidatingWebhook(caBundle, extensionNamespace, managedByGardenerObjectSelector, kubeSystemAndDashboardNamespaceSelector),
+				expectedShootMutatingWebhook(caBundle, extensionNamespace, managedByGardenerObjectSelector, kubeSystemAndDashboardNamespaceSelector),
+				expectedShootClusterRole(),
+				expectedShootRoleBinding(shootAccessServiceAccountName, scope, "kube-system"),
+				expectedShootRoleBinding(shootAccessServiceAccountName, scope, "kubernetes-dashboard"),
 			))
 		})
 
 		DescribeTable("Should ensure the mutating webhook config is correctly set",
 			func(ca []byte, ns string) {
-				resources, err := getShootResources(ca, ns, shootAccessServiceAccountName, scope)
+				resources, err := getShootResources(ca, ns, shootAccessServiceAccountName, scope, dashboardEnabled)
 				Expect(err).ToNot(HaveOccurred())
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
@@ -119,7 +164,7 @@ var _ = Describe("Actuator", func() {
 
 		DescribeTable("Should ensure the validating webhook config is correctly set",
 			func(ca []byte, ns string) {
-				resources, err := getShootResources(ca, ns, shootAccessServiceAccountName, scope)
+				resources, err := getShootResources(ca, ns, shootAccessServiceAccountName, scope, dashboardEnabled)
 				Expect(err).ToNot(HaveOccurred())
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
@@ -130,9 +175,9 @@ var _ = Describe("Actuator", func() {
 			Entry("Custom CA bundle and namespace name", []byte("anotherCABundle"), "different-namespace"),
 		)
 
-		DescribeTable("Should return an empty object selector for the webhooks when shoot is in the garden namespace",
+		DescribeTable("Should return an empty object selector for the webhooks when scope is KubeSystem",
 			func(ca []byte, ns string) {
-				resources, err := getShootResources(ca, ns, shootAccessServiceAccountName, v1beta1constants.GardenNamespace)
+				resources, err := getShootResources(ca, ns, shootAccessServiceAccountName, lakom.KubeSystem, dashboardEnabled)
 				Expect(err).ToNot(HaveOccurred())
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
@@ -147,22 +192,22 @@ var _ = Describe("Actuator", func() {
 		)
 
 		DescribeTable("Should ensure the rolebinding is correctly set",
-			func(saName string, lakomScope lakom.ScopeType) {
-				resources, err := getShootResources(caBundle, extensionNamespace, saName, lakomScope)
+			func(saName string, lakomScope lakom.ScopeType, bindingNamespace string) {
+				resources, err := getShootResources(caBundle, extensionNamespace, saName, lakomScope, dashboardEnabled)
 				Expect(err).ToNot(HaveOccurred())
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
 
-				Expect(manifests).To(ContainElement(expectedShootRoleBinding(saName, lakomScope)))
+				Expect(manifests).To(ContainElement(expectedShootRoleBinding(saName, lakomScope, bindingNamespace)))
 			},
-			Entry("ServiceAccount name: test, scope: KubeSystemManagedByGardener", "test", lakom.KubeSystemManagedByGardener),
-			Entry("ServiceAccount name: foo-bar, scope: KubeSystem", "foo-bar", lakom.KubeSystem),
-			Entry("ServiceAccount name: foo-bar, scope: Cluster", "foo-bar", lakom.Cluster),
+			Entry("ServiceAccount name: test, scope: KubeSystemManagedByGardener", "test", lakom.KubeSystemManagedByGardener, "kube-system"),
+			Entry("ServiceAccount name: foo-bar, scope: KubeSystem", "foo-bar", lakom.KubeSystem, "kube-system"),
+			Entry("ServiceAccount name: foo-bar, scope: Cluster", "foo-bar", lakom.Cluster, ""),
 		)
 
 		DescribeTable("Should return the correct object and namespace selectors based on scope",
 			func(scope lakom.ScopeType, objectSelector, namespaceSelector string) {
-				resources, err := getShootResources(caBundle, extensionNamespace, shootAccessServiceAccountName, scope)
+				resources, err := getShootResources(caBundle, extensionNamespace, shootAccessServiceAccountName, scope, dashboardEnabled)
 				Expect(err).ToNot(HaveOccurred())
 				manifests, err := test.ExtractManifestsFromManagedResourceData(resources)
 				Expect(err).ToNot(HaveOccurred())
@@ -479,7 +524,7 @@ rules:
 `
 }
 
-func expectedShootRoleBinding(saName string, lakomScope lakom.ScopeType) string {
+func expectedShootRoleBinding(saName string, lakomScope lakom.ScopeType, namespace string) string {
 	if lakomScope == lakom.Cluster {
 		return `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -510,7 +555,7 @@ metadata:
     app.kubernetes.io/name: lakom
     app.kubernetes.io/part-of: shoot-lakom-service
   name: gardener-extension-shoot-lakom-service-resource-reader
-  namespace: kube-system
+  namespace: ` + namespace + `
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
**How to categorize this PR?**
/area security
/kind bug

**What this PR does / why we need it**:
Fix `KubeSystem*` scopes to verify also the pods in the `kubernetes-dashboard` namespace.
When a Shoot cluster has the KubernetesDashboard addon enabled, Gardener creates the namespace `kubernetes-dashboard` and deploys workload in it, the scopes `KubeSystem` and `KubeSystemManagedByGardener` now include this namespace when the addon is enabled.

**Which issue(s) this PR fixes**:
As a side quest, also fixes #246 

**Special notes for your reviewer**:
Based on #307 due to merge confilcts

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Lakom admission scopes `KubeSystem` and `KubeSystemManagedByGardener` are extended to admit workload also in the `kubernetes-dashboard` namespace when the shoot addon `KubernetesDashboard` is enabled. 
```