### PR TITLE
Move the go-yaml version hint component descriptor label to the top-level

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -2,6 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+labels:
+  - name: cloud.gardener.cnudie/dso/scanning-hints/package-versions
+    value:
+      - name: go-yaml # Explicitly set the version of gopkg.in/yaml.v2 for scanning tools that cannot detect it properly.
+        version: v2.4.0
+
 main-source:
   labels:
     - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1
@@ -9,7 +15,3 @@ main-source:
         policy: skip
         comment: |
           we use gosec for sast scanning. See attached log.
-    - name: cloud.gardener.cnudie/dso/scanning-hints/package-versions
-      value:
-        - name: go-yaml # Explicitly set the version of gopkg.in/yaml.v2 for scanning tools that cannot detect it properly.
-          version: v2.4.0


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity 
/kind bug

**What this PR does / why we need it**:
Move the go-yaml version hint component descriptor label to the top-level
Scanning tools may ignore the labels in the 'main-source', let's set the hint in the top-level labels where they should honor it.

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener-extension-shoot-lakom-service/pull/275

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```