### PR TITLE
Scrape controller runtime webhook request metrics

### DIFF
--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -602,7 +602,7 @@ func getSeedResources(
 				Selector: metav1.LabelSelector{MatchLabels: getLabels()},
 				Endpoints: []monitoringv1.Endpoint{{
 					Port:                 "metrics",
-					MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig("lakom.*"),
+					MetricRelabelConfigs: monitoringutils.StandardMetricRelabelConfig("lakom_.*", "controller_runtime_webhook_.*"),
 				}},
 			},
 		},

--- a/pkg/controller/lifecycle/actuator_test.go
+++ b/pkg/controller/lifecycle/actuator_test.go
@@ -579,7 +579,7 @@ spec:
   endpoints:
   - metricRelabelings:
     - action: keep
-      regex: ^(lakom.*)$
+      regex: ^(lakom_.*|controller_runtime_webhook_.*)$
       sourceLabels:
       - __name__
     port: metrics


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR extends the `ServiceMonitor` to additionally scrape the controller runtime webhook metrics.

Since the `lakom` metrics are lazy and only appear once they are not zero, enabling the Prometheus health check feature gate introduced by https://github.com/gardener/gardener/pull/13341 will fail the `ObservabilityComponentsHealthy` condition for as long as these metrics do not show up. Such health check is used to report misconfigured scrape jobs that do not produce metrics. However, this becomes a false negative when only lazy metrics are scraped.

Scraping the controller runtime metrics fixes the issue because these are always available.

**Special notes for your reviewer**:

/cc @istvanballok

**Release note**:

```other operator
The `ServiceMonitor` is now configured to scrape the controller runtime webhook metrics.
```