### PR TITLE
Add e2e test make command and script placeholders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,10 @@ test-cov:
 test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
+.PHONY: ci-e2e-kind
+ci-e2e-kind: $(KIND) $(YQ)
+	./hack/ci-e2e-kind.sh
+
 .PHONY: verify
 verify: check format test sast
 

--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ test-clean:
 	@bash $(GARDENER_HACK_DIR)/test-cover-clean.sh
 
 .PHONY: ci-e2e-kind
-ci-e2e-kind: $(KIND) $(YQ)
+ci-e2e-kind:
 	./hack/ci-e2e-kind.sh
 
 .PHONY: verify

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -1,0 +1,1 @@
+echo "e2e tests placeholder..."

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -1,1 +1,7 @@
+#!/bin/bash
+
+# SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+
 echo "e2e tests placeholder..."

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 #


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area security
  /area documentation
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|compliance|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|flake|impediment|poc|post-mortem|question|regression|task|technical-debt|test

-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Adds an e2e make command and script placeholders to help validate end-to-end tests currently under development.

**Which issue(s) this PR fixes**:
Related to https://github.com/gardener/gardener-extension-shoot-lakom-service/issues/123

**Special notes for your reviewer**:
NONE
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```